### PR TITLE
Added full UNIX dependencies and build instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
 Installation:
 -------------
-Refer to the appropriate INSTALL files for your build system:
+Refer to the appropriate generic INSTALL files for your build system:
 
 INSTALL.unix    All UNIX builds, including cygwin
 INSTALL.win32   Microsoft Visual C++ builds
@@ -9,40 +9,47 @@ INSTALL.dos     WATCOM C/C++ builds
 Appendix to 'INSTALL.dos':
 --------------------------
 The build instructions of the WATCOM build are generic and generated
-automatically. They assume that the main Makefile would be called 'Makefile'.
-This isn't the case for AdPlug's WATCOM build! AdPlug's WATCOM Makefile is
-called 'Makefile.wat'. Thus, you have to give the commandline option
-'/f Makefile.wat' every time you run a 'wmake' command. For example, to
-install AdPlug, call wmake like this:
+automatically. They assume that the main Makefile would be called
+'Makefile'.  This isn't the case for AdPlug's WATCOM build! AdPlug's
+WATCOM Makefile is called 'Makefile.wat'. Thus, you have to give the
+commandline option '/f Makefile.wat' every time you run a 'wmake'
+command. For example, to install AdPlug, call wmake like this:
 
 wmake /f Makefile.wat install
 
 Do this similary with any other 'wmake' target.
 
-git and UNIX:
--------------
-If you checked out from git and use UNIX, first run:
+Appendix to 'INSTALL.unix':
+---------------------------
+
+This project depends on GNU Autotools (autoconf, automake, libtool,
+and gettext), texinfo, and pkg-config.
+
+Steps to build:
 
 autoreconf --install
+./configure --enable-maintainer-mode
+make
+make install
 
-to generate the build cruft and get the configure script. You need recent
-versions of autoconf, automake and libtool to do this.
+Notes:
 
-Also, you need to pass --enable-maintainer-mode to the configure script to
-generate some missing files.
+--enable-maintainer-mode generates some missing files, and is
+  currently recommended by the dev team.
 
 Extra setup for DOS and Windows builds:
 ---------------------------------------
-After you've done all steps from 'INSTALL.dos' or 'INSTALL.win32', you have
-to copy the file 'binio.h.in' to 'binio.h' (maybe overwriting it) in the
-'src' subdirectory and then open it ('binio.h'). Set all #define's in the
-configuration section of the file to your preferred settings. All items are
-documented.
+After you've done all steps from 'INSTALL.dos' or 'INSTALL.win32', you
+have to copy the file 'binio.h.in' to 'binio.h' (maybe overwriting it)
+in the 'src' subdirectory and then open it ('binio.h'). Set all
+#define's in the configuration section of the file to your preferred
+settings. All items are documented.
 
-Next, substitute the biggest (in size of bytes, as returned by the sizeof()
-operator) standard integer and floating-point types for @TYPE_INT@ and
-@TYPE_FLOAT@, respectively. Most of the time, you would just substitute 'long'
-for @TYPE_INT@ and 'double' for @TYPE_FLOAT@, but some compilers have even
-longer types, like 'long long' and 'long double'. If your compiler supports one
-of those, you can substitute them instead to be able to access even longer
-sections within your binary streams.
+Next, substitute the biggest (in size of bytes, as returned by the
+sizeof() operator) standard integer and floating-point types for
+@TYPE_INT@ and @TYPE_FLOAT@, respectively. Most of the time, you would
+just substitute 'long' for @TYPE_INT@ and 'double' for @TYPE_FLOAT@,
+but some compilers have even longer types, like 'long long' and 'long
+double'. If your compiler supports one of those, you can substitute
+them instead to be able to access even longer sections within your
+binary streams.


### PR DESCRIPTION
Addresses #4 and #5.

Changes:

### Added
- List of dependencies needed across all *nix build systems.
- Full build instructions from clean directory to install.
### Changed
- Formatted plain text file '/INSTALL' to 70 columns.
- Rewrote Unix section in more standard format.
- Made it clear the INSTALL.* files are generic build instructions.
### Removed
- Unnecessary mentions of git; The most recent release tarball still required `autoreconf --install`.