### PR TITLE
Support NuGet packages for VS2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.4.{build}
+image: Visual Studio 2017
 
 install:
 - ps: >-
@@ -39,11 +40,13 @@ build_script:
 - cmd: >-
     @echo off
 
-    "%VS140COMNTOOLS%\VsMSBuildCmd.bat"
+    "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+
+    "%VS150COMNTOOLS%\VsMSBuildCmd.bat"
 
     appveyor-retry nuget restore contrib\vs2015\vs2015.sln
 
-    FOR %%T IN (v140,v120_xp) DO ( FOR %%P IN (x86,x64) DO ( FOR %%C IN (Debug,Release) DO ( echo *** Building %%T/%%P/%%C *** && msbuild contrib\vs2015\libbinio\libbinio.vcxproj /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=%%T /p:SolutionDir=..\ /v:minimal /nologo || EXIT 1 ) ) )
+    FOR %%T IN (v141,v140,v120_xp) DO ( FOR %%P IN (x86,x64) DO ( FOR %%C IN (Debug,Release) DO ( echo *** Building %%T/%%P/%%C *** && msbuild contrib\vs2015\libbinio\libbinio.vcxproj /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=%%T /p:SolutionDir=..\ /v:minimal /nologo || EXIT 1 ) ) )
 
 before_deploy:
 - ps: >-

--- a/contrib/vs2015/libbinio.autopkg.template
+++ b/contrib/vs2015/libbinio.autopkg.template
@@ -1,6 +1,6 @@
 #define {
 	// Must match the PlatformToolset options in appveyor.yml
-	toolsets: "v140,v120_xp";
+	toolsets: "v141,v140,v120_xp";
 }
 
 configurations {


### PR DESCRIPTION
Currently appveyor only creates a NuGet package with builds up to toolset v140 (VS 2015). This disallows using the NuGet package with VS 2017 and the v141 toolset.

Add settings to build for the v141 toolset.
