### PR TITLE
Users of adplug still experiences problems with memory-mapped files

### DIFF
--- a/src/binstr.cpp
+++ b/src/binstr.cpp
@@ -45,7 +45,7 @@ void binsbase::seek(long p, Offset offs)
   }
 
   // Seek after end of data
-  if(spos - data >= length) {
+  if(spos - data > length) {
     err |= Eof;
     spos = data + length;
   }


### PR DESCRIPTION
Memory objects that uses filesize(), that again uses seek(), caused object to get stuck info EOF state