### PR TITLE
Autoupdate 1

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,14 +28,15 @@ and gettext), texinfo, and pkg-config.
 Steps to build:
 
 autoreconf --install
-./configure --enable-maintainer-mode
+./configure
 make
 make install
 
 Notes:
 
---enable-maintainer-mode generates some missing files, and is
-  currently recommended by the dev team.
+./configure automatically implies `--enable-maintainer-mode` which
+generates some missing files, and is currently recommended by the dev
+team.
 
 Extra setup for DOS and Windows builds:
 ---------------------------------------

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,5 +5,7 @@ EXTRA_DIST = INSTALL.unix INSTALL.win32 INSTALL.dos Makefile.wat Makefile.bt \
 
 AUTOMAKE_OPTIONS = dist-bzip2
 
+ACLOCAL_AMFLAGS=-I m4
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libbinio.pc

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
-AC_INIT(binio,1.5,[dn.tlp@gmx.net],libbinio)
+AC_INIT([binio],[1.5],[dn.tlp@gmx.net],[libbinio])
 AC_CONFIG_SRCDIR(src/binio.cpp)
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/binio.h libbinio.pc])
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
-#AM_DISABLE_SHARED
-AM_PROG_LIBTOOL
+#AC_DISABLE_SHARED([])
+LT_INIT
 AC_LANG(C++)
 
 # Check for a sane C/C++ build environment.
@@ -19,7 +19,7 @@ AC_CHECK_TYPE(long double, AC_SUBST(TYPE_FLOAT,"long double"),
 		   AC_SUBST(TYPE_FLOAT,double))
 
 # Conditionally build iostream wrappers
-AC_ARG_ENABLE([iostream], AC_HELP_STRING([--disable-iostream],
+AC_ARG_ENABLE([iostream], AS_HELP_STRING([--disable-iostream],
 	[Do not build iostream wrapper streams]))
 
 if test ${enable_iostream:=yes} = yes; then
@@ -30,7 +30,7 @@ else
 fi
 
 # Conditionally build std::string methods
-AC_ARG_ENABLE([string], AC_HELP_STRING([--disable-string],
+AC_ARG_ENABLE([string], AS_HELP_STRING([--disable-string],
 	[Do not build std::string methods]))
 
 if test ${enable_string:=yes} = yes; then
@@ -41,7 +41,7 @@ else
 fi
 
 # Check if we are using the ISO standard C++ library
-AC_ARG_WITH([iso],AC_HELP_STRING([--with-iso],
+AC_ARG_WITH([iso],AS_HELP_STRING([--with-iso],
 	[Force ISO C++ standard library compliance]))
 
 if test x${with_iso} = xyes; then
@@ -56,7 +56,7 @@ else
 fi
 
 # Conditionally build with 'math.h' (and maybe library) dependencies
-AC_ARG_WITH([math],AC_HELP_STRING([--without-math],
+AC_ARG_WITH([math],AS_HELP_STRING([--without-math],
 	[Do not build routines depending on 'math.h']))
 
 if test ${with_math:=yes} = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([binio],[1.5],[dn.tlp@gmx.net],[libbinio])
 AC_CONFIG_SRCDIR(src/binio.cpp)
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/binio.h libbinio.pc])
 AM_INIT_AUTOMAKE
-AM_MAINTAINER_MODE
+AM_MAINTAINER_MODE([enable])
 #AC_DISABLE_SHARED([])
 LT_INIT
 AC_LANG(C++)

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_INIT([binio],[1.5],[dn.tlp@gmx.net],[libbinio])
 AC_CONFIG_SRCDIR(src/binio.cpp)
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/binio.h libbinio.pc])
+AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE([enable])
 #AC_DISABLE_SHARED([])

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,0 +1,6 @@
+# We keep this .gitignore inside the m4 directory to ensure that m4 directory exists
+libtool.m4
+lt~obsolete.m4
+ltoptions.m4 
+ltsugar.m4 
+ltversion.m4


### PR DESCRIPTION
* Ran `autoupdate` to update deprecated macros in configure.ac
* Enable maintainer-mode by default, to remove possible confusion by persons trying to build this library from scratch
* Implement m4 macro-directory