### PR TITLE
Add 1.5 documentation to the libbinio github pages

### DIFF
--- a/doc/libbinio/1.5/Alien-architectures.html
+++ b/doc/libbinio/1.5/Alien-architectures.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Alien architectures (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Alien architectures (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Alien architectures (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Wrapping-around-iostream.html" rel="next" title="Wrapping around iostream">
+<link href="Seeking.html" rel="prev" title="Seeking">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Alien-architectures">
+<div class="nav-panel">
+<p>
+Next: <a href="Wrapping-around-iostream.html" accesskey="n" rel="next">Wrapping around iostream</a>, Previous: <a href="Seeking.html" accesskey="p" rel="prev">Seeking</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Alien-architectures-1">2.6 Alien architectures</h3>
+<a class="index-entry-id" id="index-Alien-architectures"></a>
+
+<p>All the above mentioned procedures expect the data to be in the format
+of your machine&rsquo;s own idea of how the data has to be stored. However,
+there are situations where you have to read and even write binary data
+for some other, incompatible architecture.
+</p>
+<a class="index-entry-id" id="index-Other-Architectures"></a>
+<p>All architectures that are incompatible with the architecture,
+libbinio is currently running on, are called <em class="dfn">alien</em>
+architectures.
+</p>
+<a class="index-entry-id" id="index-Data-conversion"></a>
+<a class="index-entry-id" id="index-Converting-from-other-architectures"></a>
+<p>libbinio makes the process of converting between your architecture&rsquo;s
+and the alien architecture&rsquo;s idea of binary storage completely
+transparent to you. All you have to do is to specify some
+characteristics about the stream&rsquo;s binary format, after you have
+opened it. All newly created streams are initialized with the current
+system&rsquo;s binary characteristics, so you don&rsquo;t have to do anything if
+you just want to access data of your own architecture.
+</p>
+<a class="index-entry-id" id="index-Setting-flags"></a>
+<a class="index-entry-id" id="index-Reading-flags"></a>
+<a class="index-entry-id" id="index-Flags"></a>
+<p>You use the <code class="code">setFlag(<var class="var">flag</var>, [<var class="var">set</var>])</code> and
+<code class="code">getFlag(<var class="var">flag</var>)</code> methods to set and read a stream&rsquo;s
+characteristics. <var class="var">flag</var> specifies the flag to be set or read
+(refer to <a class="ref" href="Reference.html">Reference</a> for information on what flags are available
+and their meaning). The optional argument <var class="var">set</var> specifies whether
+the flag should be set (the default) or erased.
+</p>
+<p>After you have set up all flags to sufficiently specify the alien
+architecture, you can proceed to do binary I/O, just as described in
+the previous chapters and libbinio will do all the necessary
+conversion between your own and the alien architecture for you.
+</p>
+<p>If you ever happen to have binary data of multiple, incompatbile,
+alien architectures in a single stream (very unlikely), you can re-set
+any of the flags to any other value, in between any of the other
+stream access method calls. The stream will adhere to the new flag
+values instantly with the next data access.
+</p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Wrapping-around-iostream.html">Wrapping around iostream</a>, Previous: <a href="Seeking.html">Seeking</a>, Up: <a href="Usage.html">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Base-classes.html
+++ b/doc/libbinio/1.5/Base-classes.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Base classes (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Base classes (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Base classes (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="File-streams.html" rel="next" title="File streams">
+<link href="Configuration.html" rel="prev" title="Configuration">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Base-classes">
+<div class="nav-panel">
+<p>
+Next: <a href="File-streams.html" accesskey="n" rel="next">File streams</a>, Previous: <a href="Configuration.html" accesskey="p" rel="prev">Configuration</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Base-classes-1">3.3 Base classes</h3>
+<a class="index-entry-id" id="index-Base-classes"></a>
+
+<p>The base classes provide a common base for all derived libbinio stream
+classes. They define important methods, types and variables.
+</p>
+<p>One general and three stream base classes are defined in the file
+<samp class="file">binio.h</samp>, which make up the libbinio base classes.
+</p>
+
+<ul class="mini-toc">
+<li><a href="binio.html" accesskey="1">binio</a></li>
+<li><a href="binistream.html" accesskey="2">binistream</a></li>
+<li><a href="binostream.html" accesskey="3">binostream</a></li>
+<li><a href="binstream.html" accesskey="4">binstream</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Basics.html
+++ b/doc/libbinio/1.5/Basics.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Basics (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Basics (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Basics (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Files.html" rel="next" title="Files">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Basics">
+<div class="nav-panel">
+<p>
+Next: <a href="Files.html" accesskey="n" rel="next">Files</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Basics-1">2.1 Basics</h3>
+<a class="index-entry-id" id="index-Basics"></a>
+
+<p>The binary stream class framework divides streams into
+<a class="index-entry-id" id="index-input_002donly"></a>
+<em class="dfn">input-only</em>,
+<a class="index-entry-id" id="index-output_002donly"></a>
+<em class="dfn">output-only</em> and
+<a class="index-entry-id" id="index-input_002foutput"></a>
+<em class="dfn">input/output</em> supporting
+streams. All derived classes also inherit this partition.
+</p>
+<p>All derived classes that come with the library follow a uniform naming
+scheme. You can identify what I/O facilities a stream provides, by
+looking at the class name. All class names of libbinio start with
+&lsquo;<samp class="samp">bin</samp>&rsquo; and end with a descriptive name of what they are meant
+for. In between is at most one character that describes what I/O
+functionality is provided. If this character is an &lsquo;<samp class="samp">i</samp>&rsquo;, the class
+provides input-only streams, &lsquo;<samp class="samp">o</samp>&rsquo; means output-only and no
+character indicates both input and output facilities.
+</p>
+<p>For example, <code class="code">binifstream</code> is an input-only binary stream for
+standard file access. <code class="code">binstream</code> is the general input and output
+supporting stream.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Class-Index.html
+++ b/doc/libbinio/1.5/Class-Index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Class Index (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Class Index (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Class Index (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Method-Index.html" rel="next" title="Method Index">
+<link href="Concept-Index.html" rel="prev" title="Concept Index">
+<style type="text/css">
+<!--
+a.summary-letter-printindex {text-decoration: none}
+td.printindex-index-entry {vertical-align: top}
+td.printindex-index-section {vertical-align: top}
+th.entries-header-printindex {text-align:left}
+th.sections-header-printindex {text-align:left}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="unnumbered-level-extent" id="Class-Index">
+<div class="nav-panel">
+<p>
+Next: <a href="Method-Index.html" accesskey="n" rel="next">Method Index</a>, Previous: <a href="Concept-Index.html" accesskey="p" rel="prev">Concept Index</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="unnumbered" id="Class-Index-1">Class Index</h2>
+
+<div class="printindex tp-printindex">
+<table class="tp-entries-printindex" border="0">
+<tr><td></td><th class="entries-header-printindex">Index Entry</th><td>&nbsp;</td><th class="sections-header-printindex"> Section</th></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Class-Index_tp_letter-B">B</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-binfbase"><code>binfbase</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binfbase-1"><code>binfbase</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binfstream"><code>binfstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binifstream"><code>binifstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-binio"><code>binio</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binisstream"><code>binisstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-binistream"><code>binistream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-biniwstream"><code>biniwstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binofstream"><code>binofstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binosstream"><code>binosstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-binostream"><code>binostream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-binowstream"><code>binowstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binsbase"><code>binsbase</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binsstream"><code>binsstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binstream.html#index-binstream"><code>binstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binstream.html">binstream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-binwstream"><code>binwstream</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+</table>
+</div>
+
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Concept-Index.html
+++ b/doc/libbinio/1.5/Concept-Index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Concept Index (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Concept Index (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Concept Index (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="#Concept-Index" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Class-Index.html" rel="next" title="Class Index">
+<link href="Copying-This-Manual.html" rel="prev" title="Copying This Manual">
+<style type="text/css">
+<!--
+a.summary-letter-printindex {text-decoration: none}
+td.printindex-index-entry {vertical-align: top}
+td.printindex-index-section {vertical-align: top}
+th.entries-header-printindex {text-align:left}
+th.sections-header-printindex {text-align:left}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="unnumbered-level-extent" id="Concept-Index">
+<div class="nav-panel">
+<p>
+Next: <a href="Class-Index.html" accesskey="n" rel="next">Class Index</a>, Previous: <a href="Copying-This-Manual.html" accesskey="p" rel="prev">Copying This Manual</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="#Concept-Index" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="unnumbered" id="Concept-Index-1">Concept Index</h2>
+
+<div class="printindex cp-printindex">
+<table class="cp-letters-header-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Concept-Index_cp_letter-A"><b>A</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-C"><b>C</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-D"><b>D</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-O"><b>O</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-P"><b>P</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-R"><b>R</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-U"><b>U</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-W"><b>W</b></a>
+ &nbsp; 
+</td></tr></table>
+<table class="cp-entries-printindex" border="0">
+<tr><td></td><th class="entries-header-printindex">Index Entry</th><td>&nbsp;</td><th class="sections-header-printindex"> Section</th></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-A">A</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Concepts.html#index-Administrative-classes">Administrative classes</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Concepts.html">Concepts</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Alien-architectures">Alien architectures</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Files.html#index-Appending-to-files">Appending to files</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Files.html">Files</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-B">B</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Base-classes.html#index-Base-classes">Base classes</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Base-classes.html">Base classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Basics.html#index-Basics">Basics</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Basics.html">Basics</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-C">C</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Files.html#index-Closing-files">Closing files</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Files.html">Files</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-Compile_002dtime-configuration">Compile-time configuration</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Concepts.html#index-Concepts">Concepts</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Concepts.html">Concepts</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-Configuration">Configuration</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Concepts.html#index-Conversion-layer">Conversion layer</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Concepts.html">Concepts</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Converting-from-other-architectures">Converting from other architectures</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Copying-This-Manual.html#index-Copying-this-manual">Copying this manual</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Copying-This-Manual.html">Copying This Manual</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Creating-architecture_002dindependent-file-formats.html#index-Creating-architecture_002dindependent-file-formats">Creating architecture-independent file formats</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Creating-architecture_002dindependent-file-formats.html">Creating architecture-independent file formats</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-D">D</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Data-conversion">Data conversion</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-E">E</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Errors.html#index-End-of-file-error-checking">End of file error checking</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Errors.html">Errors</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Errors.html#index-Errors">Errors</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Errors.html">Errors</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Examples.html#index-Examples">Examples</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Examples.html">Examples</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-F">F</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="FAQ.html#index-FAQ">FAQ</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="FAQ.html">FAQ</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="GNU-Free-Documentation-License.html#index-FDL_002c-GNU-Free-Documentation-License">FDL, GNU Free Documentation License</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="GNU-Free-Documentation-License.html">GNU Free Documentation License</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Features.html#index-Features">Features</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Features.html">Features</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Files.html#index-File-open-mode">File open mode</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Files.html">Files</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-File-stream-classes">File stream classes</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-streams.html#index-File-streams">File streams</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-streams.html">File streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Files.html#index-Files">Files</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Files.html">Files</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Flags">Flags</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-I">I</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Basics.html#index-input_002donly">input-only</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Basics.html">Basics</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Basics.html#index-input_002foutput">input/output</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Basics.html">Basics</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Introduction.html#index-Introduction">Introduction</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Introduction.html">Introduction</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Wrapping-around-iostream.html#index-iostream-wrappers">iostream wrappers</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Wrapping-around-iostream.html">Wrapping around iostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-iostream-wrappers-1">iostream wrappers</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-O">O</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Files.html#index-Opening-files">Opening files</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Files.html">Files</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Other-Architectures">Other Architectures</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Basics.html#index-output_002donly">output-only</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Basics.html">Basics</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-P">P</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Seeking.html#index-Positioning">Positioning</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Seeking.html">Seeking</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-R">R</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Reading-and-Writing.html#index-Reading">Reading</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Reading-and-Writing.html">Reading and Writing</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Reading-flags">Reading flags</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Reference.html#index-Reference">Reference</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Reference.html">Reference</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-S">S</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Seeking.html#index-Seeking">Seeking</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Seeking.html">Seeking</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Alien-architectures.html#index-Setting-flags">Setting flags</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Alien-architectures.html">Alien architectures</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Errors.html#index-Simple-error-checking">Simple error checking</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Errors.html">Errors</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Concepts.html#index-Stream-layer">Stream layer</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Concepts.html">Concepts</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-String-streams">String streams</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-U">U</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Usage.html#index-Usage">Usage</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Usage.html">Usage</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Concept-Index_cp_letter-W">W</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Wrapping-around-iostream.html#index-Wrapping-around-iostream">Wrapping around iostream</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Wrapping-around-iostream.html">Wrapping around iostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Reading-and-Writing.html#index-Writing">Writing</a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Reading-and-Writing.html">Reading and Writing</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+</table>
+<table class="cp-letters-footer-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Concept-Index_cp_letter-A"><b>A</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-C"><b>C</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-D"><b>D</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-O"><b>O</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-P"><b>P</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-R"><b>R</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-U"><b>U</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Concept-Index_cp_letter-W"><b>W</b></a>
+ &nbsp; 
+</td></tr></table>
+</div>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Class-Index.html">Class Index</a>, Previous: <a href="Copying-This-Manual.html">Copying This Manual</a>, Up: <a href="index.html">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="#Concept-Index" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Concepts.html
+++ b/doc/libbinio/1.5/Concepts.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Concepts (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Concepts (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Concepts (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="Configuration.html" rel="next" title="Configuration">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Concepts">
+<div class="nav-panel">
+<p>
+Next: <a href="Configuration.html" accesskey="n" rel="next">Configuration</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Concepts-1">3.1 Concepts</h3>
+<a class="index-entry-id" id="index-Concepts"></a>
+
+<p>The libbinio stream classes can be divided into two layers of
+functionality:
+</p>
+<ol class="enumerate">
+<li> <a class="index-entry-id" id="index-Conversion-layer"></a>
+The <em class="dfn">conversion layer</em> provides methods for transparently
+converting the data, that has just been read from or is to be written
+to a stream, between the current and the alien architecture. The
+<code class="code">binistream</code>, <code class="code">binostream</code> and <code class="code">binstream</code> classes
+belong to this layer.
+</li><li> <a class="index-entry-id" id="index-Stream-layer"></a>
+The <em class="dfn">stream layer</em> faciliates functionality on the stream
+level. It provides methods for byte-by-byte access to the data,
+seeking, opening and closing a stream and anything else related to the
+maintenance of a stream. The <code class="code">binfstream</code>, <code class="code">binwstream</code> and
+<code class="code">binsstream</code> related classes belong to this layer.
+</li></ol>
+
+<a class="index-entry-id" id="index-Administrative-classes"></a>
+<p>Additionally, there are some administrative and auxiliary classes
+provided, which do not belong to any of the above defined layers. The
+<code class="code">binio</code> base class belongs here, for example.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Configuration.html
+++ b/doc/libbinio/1.5/Configuration.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Configuration (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Configuration (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Configuration (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="Base-classes.html" rel="next" title="Base classes">
+<link href="Concepts.html" rel="prev" title="Concepts">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Configuration">
+<div class="nav-panel">
+<p>
+Next: <a href="Base-classes.html" accesskey="n" rel="next">Base classes</a>, Previous: <a href="Concepts.html" accesskey="p" rel="prev">Concepts</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Configuration-1">3.2 Configuration</h3>
+<a class="index-entry-id" id="index-Configuration"></a>
+<a class="index-entry-id" id="index-Compile_002dtime-configuration"></a>
+
+<p>libbinio can be configured in various ways at compile time and some
+parts of the library can be disabled to save disk space and/or
+processing speed.
+</p>
+<p>In some cases, these configuration options directly change parts of
+the interface and must thus also be known by the library user.
+</p>
+<p>To make these options available to the library user, libbinio defines
+some C preprocessor macros in <samp class="file">binio.h</samp>. These are:
+</p>
+<dl class="vtable">
+<dt id='index-BINIO_005fENABLE_005fSTRING'><span><code class="code">BINIO_ENABLE_STRING</code><a class="copiable-link" href='#index-BINIO_005fENABLE_005fSTRING'> &para;</a></span></dt>
+<dd><p>If this macro expands to &lsquo;<samp class="samp">1</samp>&rsquo;, <abbr class="acronym">STL</abbr> <code class="code">string</code> object
+support is enabled and can be used instead of traditional C
+<abbr class="acronym">ASCIIZ</abbr> pointers with all functions that expect a string
+somewhere. It expands to &lsquo;<samp class="samp">0</samp>&rsquo; otherwise.
+</p></dd>
+<dt id='index-BINIO_005fENABLE_005fIOSTREAM'><span><code class="code">BINIO_ENABLE_IOSTREAM</code><a class="copiable-link" href='#index-BINIO_005fENABLE_005fIOSTREAM'> &para;</a></span></dt>
+<dd><p>If this macro expands to &lsquo;<samp class="samp">1</samp>&rsquo;, the iostream wrapper classes are
+enabled and can be used by the library user. It expands to &lsquo;<samp class="samp">0</samp>&rsquo;
+otherwise and no iostream wrapper classes are present in this case.
+</p></dd>
+<dt id='index-BINIO_005fISO_005fSTDLIB'><span><code class="code">BINIO_ISO_STDLIB</code><a class="copiable-link" href='#index-BINIO_005fISO_005fSTDLIB'> &para;</a></span></dt>
+<dd><p>If this macro expands to &lsquo;<samp class="samp">1</samp>&rsquo;, libbinio&rsquo;s iostream wrapper classes
+are taylored for the <abbr class="acronym">ISO</abbr> standard C++ library, instead of a
+&ldquo;traditional&rdquo; iostream implementation. It expands to &lsquo;<samp class="samp">0</samp>&rsquo;
+otherwise. This macro is merely for libbinio&rsquo;s internal use and should
+not be used by an application programmer.
+</p></dd>
+<dt id='index-BINIO_005fWITH_005fMATH'><span><code class="code">BINIO_WITH_MATH</code><a class="copiable-link" href='#index-BINIO_005fWITH_005fMATH'> &para;</a></span></dt>
+<dd><p>This macro is for libbinio&rsquo;s internal use and should not be used by an
+application programmer.
+</p></dd>
+</dl>
+
+<p>All macros are <em class="emph">always</em> defined. The decision whether a feature
+is enabled in the library has to be based on the value of these
+macros, not whether they are defined or not.
+</p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Base-classes.html">Base classes</a>, Previous: <a href="Concepts.html">Concepts</a>, Up: <a href="Reference.html">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Copying-This-Manual.html
+++ b/doc/libbinio/1.5/Copying-This-Manual.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Copying This Manual (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Copying This Manual (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Copying This Manual (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Concept-Index.html" rel="next" title="Concept Index">
+<link href="FAQ.html" rel="prev" title="FAQ">
+
+
+</head>
+
+<body lang="en">
+<div class="appendix-level-extent" id="Copying-This-Manual">
+<div class="nav-panel">
+<p>
+Next: <a href="Concept-Index.html" accesskey="n" rel="next">Concept Index</a>, Previous: <a href="FAQ.html" accesskey="p" rel="prev">FAQ</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="appendix" id="Copying-This-Manual-1">Appendix B Copying This Manual</h2>
+<a class="index-entry-id" id="index-Copying-this-manual"></a>
+
+
+
+<ul class="mini-toc">
+<li><a href="GNU-Free-Documentation-License.html" accesskey="1">GNU Free Documentation License</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Creating-architecture_002dindependent-file-formats.html
+++ b/doc/libbinio/1.5/Creating-architecture_002dindependent-file-formats.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Creating architecture-independent file formats (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Creating architecture-independent file formats (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Creating architecture-independent file formats (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Examples.html" rel="next" title="Examples">
+<link href="Errors.html" rel="prev" title="Errors">
+<style type="text/css">
+<!--
+div.example {margin-left: 3.2em}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Creating-architecture_002dindependent-file-formats">
+<div class="nav-panel">
+<p>
+Next: <a href="Examples.html" accesskey="n" rel="next">Examples</a>, Previous: <a href="Errors.html" accesskey="p" rel="prev">Errors</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Creating-architecture_002dindependent-file-formats-1">2.9 Creating architecture-independent file formats</h3>
+<a class="index-entry-id" id="index-Creating-architecture_002dindependent-file-formats"></a>
+
+<p>libbinio does not inherently support any specific file format. This is
+considered a feature, as it also does not impose any file format upon
+the user.
+</p>
+<p>It is, however, very easy to create your own architecture-independent
+file format or enhance a file format to make it architecture-independent
+on top of libbinio, by creating wrapper classes that you use to access
+your streams.
+</p>
+<p>Here is an example that inserts a two byte header in front of your file
+format to make it architecture-independent:
+</p>
+<div class="example">
+<pre class="example-preformatted">class myifstream: public binifstream
+{
+public:
+  void open(const char *filename, const Mode mode = NoCreate)
+  {
+    binifstream::open(filename, mode);
+
+    setFlag(binio::BigEndian, getByte());
+    setFlag(binio::FloatIEEE, getByte());
+  }
+};
+
+class myofstream: public binofstream
+{
+public:
+  void open(const char *filename, const Mode mode = NoCreate)
+  {
+    binofstream::open(filename, mode);
+
+    putByte(getFlag(binio::BigEndian));
+    putByte(getFlag(binio::FloatIEEE));
+  }
+};
+</pre></div>
+
+<p>You can use these new classes as usual.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Errors.html
+++ b/doc/libbinio/1.5/Errors.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Errors (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Errors (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Errors (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Creating-architecture_002dindependent-file-formats.html" rel="next" title="Creating architecture-independent file formats">
+<link href="Wrapping-around-iostream.html" rel="prev" title="Wrapping around iostream">
+<style type="text/css">
+<!--
+div.example {margin-left: 3.2em}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Errors">
+<div class="nav-panel">
+<p>
+Next: <a href="Creating-architecture_002dindependent-file-formats.html" accesskey="n" rel="next">Creating architecture-independent file formats</a>, Previous: <a href="Wrapping-around-iostream.html" accesskey="p" rel="prev">Wrapping around iostream</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Errors-1">2.8 Errors</h3>
+<a class="index-entry-id" id="index-Errors"></a>
+
+<p>When doing stream I/O, some unpredictable, erroneus situations can
+occur at runtime. Binary streams are no exception to this
+phenomenon. To provide some sort of protection against this, all
+libbinio stream classes inherit an error reporting method called
+<code class="code">error()</code>.
+</p>
+<p>It is a good idea to check the error status of a stream once in a
+while to see if everything is still in place. <code class="code">error()</code> returns a
+variable of type <code class="code">Error</code>, which is an integer that holds a bit
+field of error values for that stream. Refer to <a class="ref" href="Reference.html">Reference</a> for
+information about the possible values of this variable and their
+meaning.
+</p>
+<a class="index-entry-id" id="index-Simple-error-checking"></a>
+<p>A status of no error is always reported with a value of &lsquo;<samp class="samp">0</samp>&rsquo;, so
+you can easily check if everything is still okay in a simple <code class="code">if</code>
+construct, like this:
+</p>
+<div class="example">
+<pre class="example-preformatted">if(mystream.error())
+  // an error occured, do something to cure it...
+else
+  // everything is still okay!
+</pre></div>
+
+<p>Two convenience error reporting methods are also included:
+</p>
+<a class="index-entry-id" id="index-End-of-file-error-checking"></a>
+<p><code class="code">eof()</code> only checks for the <code class="code">Eof</code> error status, indicating
+whether the end of the stream has just been passed. It returns a
+boolean value, indicating the past the end of the stream.
+</p>
+<p><code class="code">ateof()</code> is like <code class="code">eof()</code> but returns true already when the
+stream pointer is at the last byte of the stream, not past it. This is
+useful when you want to read an entire file into memory in a
+<code class="code">while(!ateof())</code> loop. This method is only defined on streams
+that support reading. On write-only streams, it is not defined and not
+useful.
+</p>
+<p>Whenever you call <code class="code">error()</code>, the internal error variable is reset
+to the <code class="code">NoError</code> state, indicating no error at all, and a
+subsequent call to any of the error reporting methods will return
+&lsquo;<samp class="samp">NoError</samp>&rsquo; again. <code class="code">eof()</code> and <code class="code">ateof()</code> do not reset the
+internal error variable. The last error status of the stream is
+retained.
+</p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Creating-architecture_002dindependent-file-formats.html">Creating architecture-independent file formats</a>, Previous: <a href="Wrapping-around-iostream.html">Wrapping around iostream</a>, Up: <a href="Usage.html">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Examples.html
+++ b/doc/libbinio/1.5/Examples.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Examples (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Examples (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Examples (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Creating-architecture_002dindependent-file-formats.html" rel="prev" title="Creating architecture-independent file formats">
+<style type="text/css">
+<!--
+div.example {margin-left: 3.2em}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Examples">
+<div class="nav-panel">
+<p>
+Previous: <a href="Creating-architecture_002dindependent-file-formats.html" accesskey="p" rel="prev">Creating architecture-independent file formats</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Examples-1">2.10 Examples</h3>
+<a class="index-entry-id" id="index-Examples"></a>
+
+<p>To read some data (namely integers, floats and strings) from an
+ordinary binary file on your filesystem, which was also created on
+your architecture:
+</p>
+<div class="example">
+<pre class="example-preformatted">#include &lt;binfile.h&gt;
+
+binifstream     file(&quot;test.dat&quot;);
+int             i;
+float           f;
+char            string[256];
+
+// Read a 32-bit integer
+i = file.readInt(4);
+
+// Read an IEEE-754 single (32 bits)
+f = file.readFloat(binio::Single);
+
+// Read a string until newline or max. number of chars exceeded
+file.readString(string, 256, '\n');
+</pre></div>
+
+<p>To do I/O on a file that was created on an x86 machine (i.e. Little
+Endian, <abbr class="acronym">IEEE-754</abbr> floats), while your own architecture is
+something different:
+</p>
+<div class="example">
+<pre class="example-preformatted">#include &lt;binfile.h&gt;
+
+binfstream     file;
+int            i = 1234567;
+long           pos;
+
+// open the file &quot;x86.dat&quot; for reading and writing, but do not create
+// it if it's not there.
+file.open(&quot;x86.dat&quot;, binfbase::NoCreate);
+
+// Check if we could cleanly open the file and bail out, if we
+// couldn't.
+if(file.error())
+  return ERROR;
+
+// Set Little Endian mode, with IEEE-754 floats.
+file.setFlag(binio::BigEndian, false);   // remove flag
+file.setFlag(binio::FloatIEEE);          // set flag
+
+// as we just want a demonstration, we discard all read data right away.
+
+// Read a 16-bit integer
+file.readInt(2);
+
+// Read an IEEE-754 double (64 bits)
+file.readFloat(binio::Double);
+
+// Remember our current position in the stream
+pos = file.pos();
+
+// Seek to the end of the file
+file.seek(0, binio::End);
+
+// Write our variable i, determining its size using sizeof()
+file.writeInt(i, sizeof(i));
+
+// Seek back to our former position
+file.seek(pos);
+
+// Read a byte from here
+file.readInt(1);
+
+// close the file again
+file.close();
+
+// and we're finished
+return SUCCESS;
+</pre></div>
+
+<p>To wrap around a stream from the iostream library, reading data until
+the end of the stream:
+</p>
+<div class="example">
+<pre class="example-preformatted">#include &lt;fstream&gt;
+#include &lt;binwrap.h&gt;
+
+// Open the iostream stream for reading and writing in binary mode.
+fstream file(&quot;test.dat&quot;, ios::in | ios::out | ios::bin);
+
+// Wrap a binary input-only stream around it.
+biniwstream bfile(&amp;file);
+
+// Read (and immediately discard) 24-bit integers until the end
+// of the stream.
+while(!bfile.eof())
+  bfile.readInt(3);
+</pre></div>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Previous: <a href="Creating-architecture_002dindependent-file-formats.html">Creating architecture-independent file formats</a>, Up: <a href="Usage.html">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/FAQ.html
+++ b/doc/libbinio/1.5/FAQ.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>FAQ (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="FAQ (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="FAQ (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Copying-This-Manual.html" rel="next" title="Copying This Manual">
+<link href="Reference.html" rel="prev" title="Reference">
+<style type="text/css">
+<!--
+ul.mark-bullet {list-style-type: disc}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="appendix-level-extent" id="FAQ">
+<div class="nav-panel">
+<p>
+Next: <a href="Copying-This-Manual.html" accesskey="n" rel="next">Copying This Manual</a>, Previous: <a href="Reference.html" accesskey="p" rel="prev">Reference</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="appendix" id="FAQ-1">Appendix A FAQ</h2>
+<a class="index-entry-id" id="index-FAQ"></a>
+
+<ul class="itemize mark-bullet">
+<li>Q: Why don&rsquo;t you supply general data block I/O methods, taking
+<code class="code">void</code> pointers as arguments, so i can read all my data into a
+<code class="code">struct</code> at once?
+</li><li>A: This, in general, is a broken idea. It only makes sense if
+you plan to write your program for only one architecture and want a
+fast way to read your whole data into memory. This is not what
+libbinio was meant for, so such methods will never be
+implemented. libbinio cannot know what data types your <code class="code">struct</code>
+is made of and thus cannot do any transparent data conversion. And
+there&rsquo;s even more: Most compilers align their <code class="code">struct</code>s to a
+special multiple of bytes (mostly the current architecture&rsquo;s data word
+size). libbinio doesn&rsquo;t (and cannot) know about all this and would
+just read the data byte by byte, completely ignoring the alignment and
+causing you to be unable to read any of your data.
+
+</li><li>Q: Why haven&rsquo;t you implemented error reporting using exceptions,
+instead of this darn <code class="code">error()</code> method polling?
+</li><li>A: Because exceptions aren&rsquo;t supported on all compiler
+platforms.
+</li></ul>
+
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Features.html
+++ b/doc/libbinio/1.5/Features.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Features (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Features (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Features (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Introduction.html" rel="up" title="Introduction">
+<style type="text/css">
+<!--
+ul.mark-bullet {list-style-type: disc}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Features">
+<div class="nav-panel">
+<p>
+Up: <a href="Introduction.html" accesskey="u" rel="up">Introduction</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Features-1">1.1 Features</h3>
+<a class="index-entry-id" id="index-Features"></a>
+
+<p>libbinio implements a generalized binary stream class framework, with
+the following features:
+</p>
+<ul class="itemize mark-bullet">
+<li>The ability to read arbitrary-sized integers, as long as the
+underlying system can hold the final value.
+</li><li>Conversion between Big- and Little-Endian storage.
+</li><li>Reading and writing of <abbr class="acronym">IEEE-754</abbr> single and double
+precision floating-point numbers and the conversion to/from any
+system-internal floating-point representation.
+</li></ul>
+
+<p>libbinio provides classes for streaming access to normal files,
+arbitrary data strings in memory and a wrapper around standard
+iostreams from either the <abbr class="acronym">ISO</abbr> standard C++ library, or a
+&ldquo;traditional&rdquo; iostream implementation.
+</p>
+<p>In addition, convenience methods for the <abbr class="acronym">STL</abbr> <code class="code">string</code>
+class can be enabled that support reading and writing of arbitrary
+length strings with dynamic memory allocation.
+</p>
+<p>libbinio should compile and run on as many systems as possible. If it
+does not work with your system/compiler combination, please tell me!
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/File-stream-classes.html
+++ b/doc/libbinio/1.5/File-stream-classes.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>File stream classes (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="File stream classes (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="File stream classes (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="File-streams.html" rel="up" title="File streams">
+<link href="binfbase.html" rel="prev" title="binfbase">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="File-stream-classes">
+<div class="nav-panel">
+<p>
+Previous: <a href="binfbase.html" accesskey="p" rel="prev">binfbase</a>, Up: <a href="File-streams.html" accesskey="u" rel="up">File streams</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="File-stream-classes-1">3.4.2 File stream classes</h4>
+<a class="index-entry-id" id="index-File-stream-classes"></a>
+<a class="index-entry-id" id="index-binfbase-1"></a>
+
+<p>The binary file streams consist of the classes <code class="code">binifstream</code>,
+<code class="code">binofstream</code> and <code class="code">binfstream</code>. They all inherit the
+interface from both <code class="code">binfbase</code> and <code class="code">binistream</code> and/or
+<code class="code">binostream</code>. Refer to the class reference of these classes for
+more information on the interface instead.
+</p>
+<a class="index-entry-id" id="index-binifstream"></a>
+<p><code class="code">binifstream</code> provides an input-only binary file stream. It is
+inherited from <code class="code">binistream</code>. The <code class="code">open()</code> method of this
+class ignores all passed <code class="code">mode</code> arguments, the open mode is
+always <code class="code">NoCreate</code>. The stream pointer is always positioned at the
+beginning of the stream and no files will ever be created, if they
+don&rsquo;t exist.
+</p>
+<a class="index-entry-id" id="index-binofstream"></a>
+<p><code class="code">binofstream</code> provides an output-only binary file stream. It is
+inherited from <code class="code">binostream</code>. The default open mode is
+&lsquo;<samp class="samp">0</samp>&rsquo;. A file is truncated to zero length or created if it did not
+exist previously. The stream is positioned at the beginning of the
+file. The <code class="code">NoCreate</code> mode flag has no effect with the
+<code class="code">open()</code> method of this class. Only <code class="code">Append</code> is honored,
+positioning the stream at the end of the file and not truncating
+it. The file is still created, if it did not exist.
+</p>
+<a class="index-entry-id" id="index-binfstream"></a>
+<p><code class="code">binfstream</code> provides an input and output supporting binary file
+stream. It is inherited from both <code class="code">binifstream</code> and
+<code class="code">binofstream</code>. The default open mode is &lsquo;<samp class="samp">0</samp>&rsquo;. A file is
+truncated to zero length or created if it did not exist
+previously. The stream is positioned at the beginning of the file. All
+<code class="code">mode</code> arguments are valid with the <code class="code">open()</code> method of this
+class. Refer to the list of public data types and variables of the
+<code class="code">binfbase</code> class for more information on their meaning.
+</p>
+<p>All three classes define an extra convenience constructor that has the
+same syntax as the <code class="code">open()</code> method and automatically open the
+specified file on object construction.
+</p>
+<p>For your information, here is a list of some important redefined
+methods of these classes, as explained above:
+</p>
+<h4 class="subheading" id="Header-file_003a-binfile_002eh-1">Header file: <samp class="file">binfile.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-4">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binifstream_0028_0029'><span><code class="code">binifstream()</code><a class="copiable-link" href='#index-binifstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-binofstream_0028_0029'><span><code class="code">binofstream()</code><a class="copiable-link" href='#index-binofstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-binfstream_0028_0029'><span><code class="code">binfstream()</code><a class="copiable-link" href='#index-binfstream_0028_0029'> &para;</a></span></dt>
+<dd><p>All standard constructors.
+</p>
+</dd>
+<dt id='index-_007ebinifstream_0028_0029'><span><code class="code">~binifstream()</code><a class="copiable-link" href='#index-_007ebinifstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinofstream_0028_0029'><span><code class="code">~binofstream()</code><a class="copiable-link" href='#index-_007ebinofstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinfstream_0028_0029'><span><code class="code">~binfstream()</code><a class="copiable-link" href='#index-_007ebinfstream_0028_0029'> &para;</a></span></dt>
+<dd><p>All standard destructors. They all automatically close an eventually
+open stream, on object deconstruction.
+</p>
+</dd>
+<dt id='index-binifstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-NoCreate_0029'><span><code class="code">binifstream(const char *filename, const Mode mode = NoCreate)</code><a class="copiable-link" href='#index-binifstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-NoCreate_0029'> &para;</a></span></dt>
+<dt id='index-binifstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-NoCreate_0029'><span><code class="code">binifstream(const std::string &amp;filename, const Mode mode = NoCreate)</code><a class="copiable-link" href='#index-binifstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-NoCreate_0029'> &para;</a></span></dt>
+<dd><p>Convenience constructors of the input-only stream class. Refer to the
+description of the <code class="code">open()</code> method in the list of public methods
+of the <code class="code">binfbase</code> class for syntax information.
+</p>
+</dd>
+<dt id='index-binofstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029'><span><code class="code">binofstream(const char *filename, const Mode mode = 0)</code><a class="copiable-link" href='#index-binofstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029'> &para;</a></span></dt>
+<dt id='index-binofstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029'><span><code class="code">binofstream(const std::string &amp;filename, const Mode mode = 0)</code><a class="copiable-link" href='#index-binofstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029'> &para;</a></span></dt>
+<dd><p>Convenience constructors of the output-only stream class. Refer to the
+description of the <code class="code">open()</code> method in the list of public methods
+of the <code class="code">binfbase</code> class for syntax information.
+</p>
+</dd>
+<dt id='index-binfstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029'><span><code class="code">binfstream(const char *filename, const Mode mode = 0)</code><a class="copiable-link" href='#index-binfstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029'> &para;</a></span></dt>
+<dt id='index-binfstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029'><span><code class="code">binfstream(const std::string &amp;filename, const Mode mode = 0)</code><a class="copiable-link" href='#index-binfstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029'> &para;</a></span></dt>
+<dd><p>Convenience constructors of the input and output supporting stream
+class. Refer to the description of the <code class="code">open()</code> method in the
+list of public methods of the <code class="code">binfbase</code> class for syntax
+information.
+</p>
+</dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Previous: <a href="binfbase.html">binfbase</a>, Up: <a href="File-streams.html">File streams</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/File-streams.html
+++ b/doc/libbinio/1.5/File-streams.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>File streams (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="File streams (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="File streams (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="String-streams.html" rel="next" title="String streams">
+<link href="Base-classes.html" rel="prev" title="Base classes">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="File-streams">
+<div class="nav-panel">
+<p>
+Next: <a href="String-streams.html" accesskey="n" rel="next">String streams</a>, Previous: <a href="Base-classes.html" accesskey="p" rel="prev">Base classes</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="File-streams-1">3.4 File streams</h3>
+<a class="index-entry-id" id="index-File-streams"></a>
+
+<p>File streams provide access to ordinary files on a filesystem. They
+consist of the classes <code class="code">binifstream</code>, <code class="code">binofstream</code> and
+<code class="code">binfstream</code>, which are all derived from the common base class
+<code class="code">binfbase</code>.
+</p>
+
+<ul class="mini-toc">
+<li><a href="binfbase.html" accesskey="1">binfbase</a></li>
+<li><a href="File-stream-classes.html" accesskey="2">File stream classes</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Files.html
+++ b/doc/libbinio/1.5/Files.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Files (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Files (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Files (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Reading-and-Writing.html" rel="next" title="Reading and Writing">
+<link href="Basics.html" rel="prev" title="Basics">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Files">
+<div class="nav-panel">
+<p>
+Next: <a href="Reading-and-Writing.html" accesskey="n" rel="next">Reading and Writing</a>, Previous: <a href="Basics.html" accesskey="p" rel="prev">Basics</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Files-1">2.2 Files</h3>
+<a class="index-entry-id" id="index-Files"></a>
+
+<p>For the most part, you will want to use libbinio to access normal
+binary files on your filesystem.
+</p>
+<p>This is what the <code class="code">binfstream</code> related classes are for. To use
+them, you first have to include the file <samp class="file">binfile.h</samp> within your
+code.
+</p>
+<p>This file contains four class declarations &ndash; <code class="code">binfbase</code>,
+<code class="code">binifstream</code>, <code class="code">binofstream</code> and
+<code class="code">binfstream</code>. <code class="code">binfbase</code> is a base class for the others and
+normally not used by an ordinary libbinio user. This leaves us with
+three usable classes.
+</p>
+<p>To create a binary stream on a file, just instantiate one of the three
+classes, according to what I/O facilities the stream should provide
+(see <a class="ref" href="Basics.html">Basics</a> for information on the class naming conventions).
+</p>
+<a class="index-entry-id" id="index-Opening-files"></a>
+<a class="index-entry-id" id="index-File-open-mode"></a>
+<a class="index-entry-id" id="index-Appending-to-files"></a>
+<p>To open a file, you use the <code class="code">open(<var class="var">filename</var>, [<var class="var">mode</var>])</code>
+method of one of the classes. <var class="var">filename</var> is a string (both C style
+<abbr class="acronym">ASCIIZ</abbr> strings and <abbr class="acronym">STL</abbr> <code class="code">string</code> objects can
+be passed, if supported by your compiler) containing the name of the
+file to open. Additionally, you can pass a <var class="var">mode</var> argument to
+specify a special way to open the file &ndash; this is described
+later. There&rsquo;s also a special constructor, provided for convenience,
+that opens up a file automatically when the object is created. It has
+exactly the same syntax as <code class="code">open()</code>.
+</p>
+<a class="index-entry-id" id="index-Closing-files"></a>
+<p>After usage, you can explicitly close the file with the <code class="code">close()</code>
+method. It is always a good idea to do this explicitly, though not
+needed because the file automatically will be closed on object
+deconstruction.
+</p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Reading-and-Writing.html">Reading and Writing</a>, Previous: <a href="Basics.html">Basics</a>, Up: <a href="Usage.html">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/GNU-Free-Documentation-License.html
+++ b/doc/libbinio/1.5/GNU-Free-Documentation-License.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>GNU Free Documentation License (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="GNU Free Documentation License (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="GNU Free Documentation License (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Copying-This-Manual.html" rel="up" title="Copying This Manual">
+<style type="text/css">
+<!--
+div.center {text-align:center}
+div.display {margin-left: 3.2em}
+div.example {margin-left: 3.2em}
+pre.display-preformatted {font-family: inherit}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="appendixsec-level-extent" id="GNU-Free-Documentation-License">
+<div class="nav-panel">
+<p>
+Up: <a href="Copying-This-Manual.html" accesskey="u" rel="up">Copying This Manual</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="appendixsec" id="GNU-Free-Documentation-License-1">B.1 GNU Free Documentation License</h3>
+
+<a class="index-entry-id" id="index-FDL_002c-GNU-Free-Documentation-License"></a>
+<div class="center">Version 1.1, March 2000
+</div>
+<div class="display">
+<pre class="display-preformatted">Copyright &copy; 2000 Free Software Foundation, Inc.
+59 Temple Place, Suite 330, Boston, MA  02111-1307, USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+</pre></div>
+
+<ol class="enumerate" start="0">
+<li> PREAMBLE
+
+<p>The purpose of this License is to make a manual, textbook, or other
+written document <em class="dfn">free</em> in the sense of freedom: to assure everyone
+the effective freedom to copy and redistribute it, with or without
+modifying it, either commercially or noncommercially.  Secondarily,
+this License preserves for the author and publisher a way to get
+credit for their work, while not being considered responsible for
+modifications made by others.
+</p>
+<p>This License is a kind of &ldquo;copyleft&rdquo;, which means that derivative
+works of the document must themselves be free in the same sense.  It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+</p>
+<p>We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does.  But this License is not limited to software manuals;
+it can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book.  We recommend this License
+principally for works whose purpose is instruction or reference.
+</p>
+</li><li> APPLICABILITY AND DEFINITIONS
+
+<p>This License applies to any manual or other work that contains a
+notice placed by the copyright holder saying it can be distributed
+under the terms of this License.  The &ldquo;Document&rdquo;, below, refers to any
+such manual or work.  Any member of the public is a licensee, and is
+addressed as &ldquo;you&rdquo;.
+</p>
+<p>A &ldquo;Modified Version&rdquo; of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+</p>
+<p>A &ldquo;Secondary Section&rdquo; is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document&rsquo;s overall subject
+(or to related matters) and contains nothing that could fall directly
+within that overall subject.  (For example, if the Document is in part a
+textbook of mathematics, a Secondary Section may not explain any
+mathematics.)  The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+</p>
+<p>The &ldquo;Invariant Sections&rdquo; are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License.
+</p>
+<p>The &ldquo;Cover Texts&rdquo; are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License.
+</p>
+<p>A &ldquo;Transparent&rdquo; copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, whose contents can be viewed and edited directly and
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters.  A copy made in an otherwise Transparent file
+format whose markup has been designed to thwart or discourage
+subsequent modification by readers is not Transparent.  A copy that is
+not &ldquo;Transparent&rdquo; is called &ldquo;Opaque&rdquo;.
+</p>
+<p>Examples of suitable formats for Transparent copies include plain
+<small class="sc">ASCII</small> without markup, Texinfo input format, LaTeX input format,
+<abbr class="acronym">SGML</abbr> or <abbr class="acronym">XML</abbr> using a publicly available
+<abbr class="acronym">DTD</abbr>, and standard-conforming simple <abbr class="acronym">HTML</abbr> designed
+for human modification.  Opaque formats include PostScript,
+<abbr class="acronym">PDF</abbr>, proprietary formats that can be read and edited only by
+proprietary word processors, <abbr class="acronym">SGML</abbr> or <abbr class="acronym">XML</abbr> for which
+the <abbr class="acronym">DTD</abbr> and/or processing tools are not generally available,
+and the machine-generated <abbr class="acronym">HTML</abbr> produced by some word
+processors for output purposes only.
+</p>
+<p>The &ldquo;Title Page&rdquo; means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page.  For works in
+formats which do not have any title page as such, &ldquo;Title Page&rdquo; means
+the text near the most prominent appearance of the work&rsquo;s title,
+preceding the beginning of the body of the text.
+</p>
+</li><li> VERBATIM COPYING
+
+<p>You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no other
+conditions whatsoever to those of this License.  You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute.  However, you may accept
+compensation in exchange for copies.  If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+</p>
+<p>You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+</p>
+</li><li> COPYING IN QUANTITY
+
+<p>If you publish printed copies of the Document numbering more than 100,
+and the Document&rsquo;s license notice requires Cover Texts, you must enclose
+the copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover.  Both covers must also clearly and legibly identify
+you as the publisher of these copies.  The front cover must present
+the full title with all words of the title equally prominent and
+visible.  You may add other material on the covers in addition.
+Copying with changes limited to the covers, as long as they preserve
+the title of the Document and satisfy these conditions, can be treated
+as verbatim copying in other respects.
+</p>
+<p>If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+</p>
+<p>If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a publicly-accessible computer-network location containing a complete
+Transparent copy of the Document, free of added material, which the
+general network-using public has access to download anonymously at no
+charge using public-standard network protocols.  If you use the latter
+option, you must take reasonably prudent steps, when you begin
+distribution of Opaque copies in quantity, to ensure that this
+Transparent copy will remain thus accessible at the stated location
+until at least one year after the last time you distribute an Opaque
+copy (directly or through your agents or retailers) of that edition to
+the public.
+</p>
+<p>It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to give
+them a chance to provide you with an updated version of the Document.
+</p>
+</li><li> MODIFICATIONS
+
+<p>You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it.  In addition, you must do these things in the Modified Version:
+</p>
+<ol class="enumerate" type="A" start="1">
+<li> Use in the Title Page (and on the covers, if any) a title distinct
+from that of the Document, and from those of previous versions
+(which should, if there were any, be listed in the History section
+of the Document).  You may use the same title as a previous version
+if the original publisher of that version gives permission.
+
+</li><li> List on the Title Page, as authors, one or more persons or entities
+responsible for authorship of the modifications in the Modified
+Version, together with at least five of the principal authors of the
+Document (all of its principal authors, if it has less than five).
+
+</li><li> State on the Title page the name of the publisher of the
+Modified Version, as the publisher.
+
+</li><li> Preserve all the copyright notices of the Document.
+
+</li><li> Add an appropriate copyright notice for your modifications
+adjacent to the other copyright notices.
+
+</li><li> Include, immediately after the copyright notices, a license notice
+giving the public permission to use the Modified Version under the
+terms of this License, in the form shown in the Addendum below.
+
+</li><li> Preserve in that license notice the full lists of Invariant Sections
+and required Cover Texts given in the Document&rsquo;s license notice.
+
+</li><li> Include an unaltered copy of this License.
+
+</li><li> Preserve the section entitled &ldquo;History&rdquo;, and its title, and add to
+it an item stating at least the title, year, new authors, and
+publisher of the Modified Version as given on the Title Page.  If
+there is no section entitled &ldquo;History&rdquo; in the Document, create one
+stating the title, year, authors, and publisher of the Document as
+given on its Title Page, then add an item describing the Modified
+Version as stated in the previous sentence.
+
+</li><li> Preserve the network location, if any, given in the Document for
+public access to a Transparent copy of the Document, and likewise
+the network locations given in the Document for previous versions
+it was based on.  These may be placed in the &ldquo;History&rdquo; section.
+You may omit a network location for a work that was published at
+least four years before the Document itself, or if the original
+publisher of the version it refers to gives permission.
+
+</li><li> In any section entitled &ldquo;Acknowledgments&rdquo; or &ldquo;Dedications&rdquo;,
+preserve the section&rsquo;s title, and preserve in the section all the
+substance and tone of each of the contributor acknowledgments
+and/or dedications given therein.
+
+</li><li> Preserve all the Invariant Sections of the Document,
+unaltered in their text and in their titles.  Section numbers
+or the equivalent are not considered part of the section titles.
+
+</li><li> Delete any section entitled &ldquo;Endorsements&rdquo;.  Such a section
+may not be included in the Modified Version.
+
+</li><li> Do not retitle any existing section as &ldquo;Endorsements&rdquo;
+or to conflict in title with any Invariant Section.
+</li></ol>
+
+<p>If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant.  To do this, add their titles to the
+list of Invariant Sections in the Modified Version&rsquo;s license notice.
+These titles must be distinct from any other section titles.
+</p>
+<p>You may add a section entitled &ldquo;Endorsements&rdquo;, provided it contains
+nothing but endorsements of your Modified Version by various
+parties&mdash;for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+</p>
+<p>You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version.  Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity.  If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+</p>
+<p>The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+</p>
+</li><li> COMBINING DOCUMENTS
+
+<p>You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice.
+</p>
+<p>The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy.  If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+</p>
+<p>In the combination, you must combine any sections entitled &ldquo;History&rdquo;
+in the various original documents, forming one section entitled
+&ldquo;History&rdquo;; likewise combine any sections entitled &ldquo;Acknowledgments&rdquo;,
+and any sections entitled &ldquo;Dedications&rdquo;.  You must delete all sections
+entitled &ldquo;Endorsements.&rdquo;
+</p>
+</li><li> COLLECTIONS OF DOCUMENTS
+
+<p>You may make a collection consisting of the Document and other documents
+released under this License, and replace the individual copies of this
+License in the various documents with a single copy that is included in
+the collection, provided that you follow the rules of this License for
+verbatim copying of each of the documents in all other respects.
+</p>
+<p>You may extract a single document from such a collection, and distribute
+it individually under this License, provided you insert a copy of this
+License into the extracted document, and follow this License in all
+other respects regarding verbatim copying of that document.
+</p>
+</li><li> AGGREGATION WITH INDEPENDENT WORKS
+
+<p>A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, does not as a whole count as a Modified Version
+of the Document, provided no compilation copyright is claimed for the
+compilation.  Such a compilation is called an &ldquo;aggregate&rdquo;, and this
+License does not apply to the other self-contained works thus compiled
+with the Document, on account of their being thus compiled, if they
+are not themselves derivative works of the Document.
+</p>
+<p>If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one quarter
+of the entire aggregate, the Document&rsquo;s Cover Texts may be placed on
+covers that surround only the Document within the aggregate.
+Otherwise they must appear on covers around the whole aggregate.
+</p>
+</li><li> TRANSLATION
+
+<p>Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections.  You may include a
+translation of this License provided that you also include the
+original English version of this License.  In case of a disagreement
+between the translation and the original English version of this
+License, the original English version will prevail.
+</p>
+</li><li> TERMINATION
+
+<p>You may not copy, modify, sublicense, or distribute the Document except
+as expressly provided for under this License.  Any other attempt to
+copy, modify, sublicense or distribute the Document is void, and will
+automatically terminate your rights under this License.  However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+</p>
+</li><li> FUTURE REVISIONS OF THIS LICENSE
+
+<p>The Free Software Foundation may publish new, revised versions
+of the GNU Free Documentation License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.  See
+<a class="uref" href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</a>.
+</p>
+<p>Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License &ldquo;or any later version&rdquo; applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation.  If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+</p></li></ol>
+
+<ul class="mini-toc">
+<li><a href="#ADDENDUM_003a-How-to-use-this-License-for-your-documents" accesskey="1">ADDENDUM: How to use this License for your documents</a></li>
+</ul>
+<div class="appendixsubsec-level-extent" id="ADDENDUM_003a-How-to-use-this-License-for-your-documents">
+<h4 class="appendixsubsec">B.1.1 ADDENDUM: How to use this License for your documents</h4>
+
+<p>To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+</p>
+<div class="example smallexample">
+<div class="group"><pre class="example-preformatted">  Copyright (C)  <var class="var">year</var>  <var class="var">your name</var>.
+  Permission is granted to copy, distribute and/or modify this document
+  under the terms of the GNU Free Documentation License, Version 1.1
+  or any later version published by the Free Software Foundation;
+  with the Invariant Sections being <var class="var">list their titles</var>, with the
+  Front-Cover Texts being <var class="var">list</var>, and with the Back-Cover Texts being <var class="var">list</var>.
+  A copy of the license is included in the section entitled ``GNU
+  Free Documentation License''.
+</pre></div></div>
+
+<p>If you have no Invariant Sections, write &ldquo;with no Invariant Sections&rdquo;
+instead of saying which ones are invariant.  If you have no
+Front-Cover Texts, write &ldquo;no Front-Cover Texts&rdquo; instead of
+&ldquo;Front-Cover Texts being <var class="var">list</var>&rdquo;; likewise for Back-Cover Texts.
+</p>
+<p>If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License,
+to permit their use in free software.
+</p>
+
+
+</div>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Up: <a href="Copying-This-Manual.html">Copying This Manual</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Introduction.html
+++ b/doc/libbinio/1.5/Introduction.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Introduction (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Introduction (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Introduction (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Usage.html" rel="next" title="Usage">
+<link href="index.html" rel="prev" title="Top">
+
+
+</head>
+
+<body lang="en">
+<div class="chapter-level-extent" id="Introduction">
+<div class="nav-panel">
+<p>
+Next: <a href="Usage.html" accesskey="n" rel="next">Usage</a>, Previous: <a href="index.html" accesskey="p" rel="prev">Binary I/O stream class library</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="chapter" id="Introduction-1">1 Introduction</h2>
+<a class="index-entry-id" id="index-Introduction"></a>
+
+<p>The binary I/O stream class library (libbinio) presents a
+platform-independent way to access binary data streams in C++.
+</p>
+<p>The library is hardware independent in the form that it transparently
+converts between the different forms of machine-internal binary data
+representation.
+</p>
+<p>It further employs no special I/O protocol or file format and can be
+used on arbitrary binary data sources.
+</p>
+
+<ul class="mini-toc">
+<li><a href="Features.html" accesskey="1">Features</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Method-Index.html
+++ b/doc/libbinio/1.5/Method-Index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Method Index (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Method Index (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Method Index (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Type-Variable-and-Macro-Index.html" rel="next" title="Type Variable and Macro Index">
+<link href="Class-Index.html" rel="prev" title="Class Index">
+<style type="text/css">
+<!--
+a.summary-letter-printindex {text-decoration: none}
+td.printindex-index-entry {vertical-align: top}
+td.printindex-index-section {vertical-align: top}
+th.entries-header-printindex {text-align:left}
+th.sections-header-printindex {text-align:left}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="unnumbered-level-extent" id="Method-Index">
+<div class="nav-panel">
+<p>
+Next: <a href="Type-Variable-and-Macro-Index.html" accesskey="n" rel="next">Type, Variable and Macro Index</a>, Previous: <a href="Class-Index.html" accesskey="p" rel="prev">Class Index</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="unnumbered" id="Method-Index-1">Method Index</h2>
+
+<div class="printindex fn-printindex">
+<table class="fn-letters-header-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Method-Index_fn_symbol-1"><b>~</b></a>
+ &nbsp; 
+<br>
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-L"><b>L</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-U"><b>U</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-V"><b>V</b></a>
+ &nbsp; 
+</td></tr></table>
+<table class="fn-entries-printindex" border="0">
+<tr><td></td><th class="entries-header-printindex">Index Entry</th><td>&nbsp;</td><th class="sections-header-printindex"> Section</th></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_symbol-1">~</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-_007ebinfbase_0028_0029"><code>~binfbase()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-_007ebinfstream_0028_0029"><code>~binfstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-_007ebinifstream_0028_0029"><code>~binifstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-_007ebinio_0028_0029"><code>~binio()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-_007ebinisstream_0028_0029"><code>~binisstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-_007ebinistream_0028_0029"><code>~binistream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-_007ebiniwstream_0028_0029"><code>~biniwstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-_007ebinofstream_0028_0029"><code>~binofstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-_007ebinosstream_0028_0029"><code>~binosstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-_007ebinostream_0028_0029"><code>~binostream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-_007ebinowstream_0028_0029"><code>~binowstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-_007ebinsbase_0028_0029"><code>~binsbase()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-_007ebinsstream_0028_0029"><code>~binsstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-_007ebinwstream_0028_0029"><code>~binwstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-B">B</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-binfbase_0028_0029"><code>binfbase()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binfstream_0028_0029"><code>binfstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binfstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029"><code>binfstream(const char *filename, const Mode mode = 0)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binfstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029"><code>binfstream(const std::string &amp;filename, const Mode mode = 0)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binifstream_0028_0029"><code>binifstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binifstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-NoCreate_0029"><code>binifstream(const char *filename, const Mode mode = NoCreate)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binifstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-NoCreate_0029"><code>binifstream(const std::string &amp;filename, const Mode mode = NoCreate)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-binio_0028_0029"><code>binio()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binisstream_0028void-_002astr_002c-unsigned-long-len_0029"><code>binisstream(void *str, unsigned long len)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-binistream_0028_0029"><code>binistream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-biniwstream_0028istream-_002aistr_0029"><code>biniwstream(istream *istr)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binofstream_0028_0029"><code>binofstream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binofstream_0028const-char-_002afilename_002c-const-Mode-mode-_003d-0_0029"><code>binofstream(const char *filename, const Mode mode = 0)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="File-stream-classes.html#index-binofstream_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode-_003d-0_0029"><code>binofstream(const std::string &amp;filename, const Mode mode = 0)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="File-stream-classes.html">File stream classes</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binosstream_0028void-_002astr_002c-unsigned-long-len_0029"><code>binosstream(void *str, unsigned long len)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-binostream_0028_0029"><code>binostream()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-binowstream_0028ostream-_002aostr_0029"><code>binowstream(ostream *ostr)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binsbase_0028void-_002astr_002c-unsigned-long-len_0029"><code>binsbase(void *str, unsigned long len)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-binsstream_0028void-_002astr_002c-unsigned-long-len_0029"><code>binsstream(void *str, unsigned long len)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-binwstream_0028iostream-_002astr_0029"><code>binwstream(iostream *str)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-bool-ateof_0028_0029"><code>bool ateof()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-bool-eof_0028_0029"><code>bool eof()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-bool-getFlag_0028Flag-f_0029"><code>bool getFlag(Flag f)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-E">E</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Error-error_0028_0029"><code>Error error()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-F">F</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-Float-peekFloat_0028FType-ft_0029"><code>Float peekFloat(FType ft)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Float-pow_0028Float-base_002c-signed-int-exp_0029"><code>Float pow(Float base, signed int exp)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-Float-readFloat_0028FType-ft_0029"><code>Float readFloat(FType ft)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-I">I</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-Int-peekInt_0028unsigned-int-size_0029"><code>Int peekInt(unsigned int size)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-Int-readInt_0028unsigned-int-size_0029"><code>Int readInt(unsigned int size)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-L">L</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-long-pos_0028_0029"><code>long pos()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-S">S</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-std_003a_003astring-readString_0028const-char-delim-_003d-_0027_005c0_0027_0029"><code>std::string readString(const char delim = '\0')</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-U">U</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-unsigned-long-readString_0028char-_002astr_002c-unsigned-long-maxlen_002c-const-char-delim_0029"><code>unsigned long readString(char *str, unsigned long maxlen, const char delim)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-unsigned-long-writeString_0028const-char-_002astr_002c-unsigned-long-amount-_003d-0_0029_003b"><code>unsigned long writeString(const char *str, unsigned long amount = 0);</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-unsigned-long-writeString_0028const-std_003a_003astring-_0026str_0029_003b"><code>unsigned long writeString(const std::string &amp;str);</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Method-Index_fn_letter-V">V</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-virtual-Byte-getByte_0028_0029"><code>virtual Byte getByte()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-virtual-long-pos_0028_0029"><code>virtual long pos()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-virtual-long-pos_0028_0029-1"><code>virtual long pos()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-virtual-long-pos_0028_0029-2"><code>virtual long pos()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-virtual-void-open_0028const-char-_002afilename_002c-const-Mode-mode_0029"><code>virtual void open(const char *filename, const Mode mode)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-virtual-void-open_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode_0029"><code>virtual void open(const std::string &amp;filename, const Mode mode)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-virtual-void-putByte_0028Byte_0029"><code>virtual void putByte(Byte)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029"><code>virtual void seek(long pos, Offset offs = Set)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="iostream-wrappers.html#index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029-1"><code>virtual void seek(long pos, Offset offs = Set)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="iostream-wrappers.html">iostream wrappers</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-virtual-void-seek_0028long_002c-Offset-_003d-Set_0029"><code>virtual void seek(long, Offset = Set)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-void-close_0028_0029"><code>void close()</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binistream.html#index-void-ignore_0028unsigned-long-amount-_003d-1_0029"><code>void ignore(unsigned long amount = 1)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binistream.html">binistream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029"><code>void seek(long pos, Offset offs = Set)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-void-setFlag_0028Flag-f_002c-bool-set-_003d-true_0029"><code>void setFlag(Flag f, bool set = true)</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-void-writeFloat_0028Float-f_002c-FType-ft_0029_003b"><code>void writeFloat(Float f, FType ft);</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binostream.html#index-void-writeInt_0028Int-val_002c-unsigned-int-size_0029_003b"><code>void writeInt(Int val, unsigned int size);</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binostream.html">binostream</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+</table>
+<table class="fn-letters-footer-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Method-Index_fn_symbol-1"><b>~</b></a>
+ &nbsp; 
+<br>
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-L"><b>L</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-U"><b>U</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Method-Index_fn_letter-V"><b>V</b></a>
+ &nbsp; 
+</td></tr></table>
+</div>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Type-Variable-and-Macro-Index.html">Type, Variable and Macro Index</a>, Previous: <a href="Class-Index.html">Class Index</a>, Up: <a href="index.html">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Peeking.html
+++ b/doc/libbinio/1.5/Peeking.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Peeking (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Peeking (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Peeking (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Seeking.html" rel="next" title="Seeking">
+<link href="Reading-and-Writing.html" rel="prev" title="Reading and Writing">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Peeking">
+<div class="nav-panel">
+<p>
+Next: <a href="Seeking.html" accesskey="n" rel="next">Seeking</a>, Previous: <a href="Reading-and-Writing.html" accesskey="p" rel="prev">Reading and Writing</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Peeking-1">2.4 Peeking</h3>
+
+<p>Analogous to the <code class="code">readInt()</code> and <code class="code">readFloat()</code> methods are
+the <code class="code">peekInt(<var class="var">size</var>)</code> and <code class="code">peekFloat(<var class="var">type</var>)</code>
+methods, that take the same arguments and also read an integer or a
+floating-point number from the stream. Unlike their &ldquo;<code class="code">read</code>&rdquo;
+counterparts, they don&rsquo;t modify the stream position. The next &ldquo;real&rdquo;
+access (i.e. with one of the <code class="code">read</code> methods) to the stream will
+continue as if the <code class="code">peek</code> methods have never been called.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Reading-and-Writing.html
+++ b/doc/libbinio/1.5/Reading-and-Writing.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Reading and Writing (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Reading and Writing (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Reading and Writing (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Peeking.html" rel="next" title="Peeking">
+<link href="Files.html" rel="prev" title="Files">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Reading-and-Writing">
+<div class="nav-panel">
+<p>
+Next: <a href="Peeking.html" accesskey="n" rel="next">Peeking</a>, Previous: <a href="Files.html" accesskey="p" rel="prev">Files</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Reading-and-Writing-1">2.3 Reading and Writing</h3>
+
+<p>Every binary stream class offers the same set of binary I/O methods,
+inherited from one of the general stream base classes
+<code class="code">binistream</code>, <code class="code">binostream</code> or both of them. These, in turn,
+inherit from the <code class="code">binio</code> class, which provides additional general
+methods, as well as some important type declarations.
+</p>
+<p>The binary I/O methods differenciate between integers, floating-point
+numbers and character strings.
+</p>
+<a class="index-entry-id" id="index-Reading"></a>
+<p>To read an integer from a binary stream, you would use
+<code class="code">readInt(<var class="var">size</var>)</code>. The <var class="var">size</var> argument specifies the size
+of the integer in bytes. The method returns the integer, that has just
+been read.
+</p>
+<p><code class="code">readFloat(<var class="var">type</var>)</code> reads a floating-point number of type
+<var class="var">type</var> from the stream. As all floating-point formats are well
+defined, you just have to specify the right floating-point type to
+this method and it will figure out the correct size by itself. Refer
+to <a class="ref" href="Reference.html">Reference</a> for information of what floating-point formats are
+supported and how to specify them. The method returns the
+floating-point number, that has just been read.
+</p>
+<p>A character string can be read by using the <code class="code">readString()</code>
+method. To read a character string into a pre-allocated C style
+<abbr class="acronym">ASCIIZ</abbr> string buffer, you would use
+<code class="code">readString(<var class="var">string</var>, <var class="var">max-length</var>, [<var class="var">delimiter</var>])</code>
+and give a pointer to the string buffer with <var class="var">string</var>, the maximum
+length of the string (<em class="emph">not</em> including the final &lsquo;<samp class="samp">\0</samp>&rsquo;) in
+<var class="var">max-length</var> and optionally a delimiter character <var class="var">delimiter</var>,
+at which libbinio would stop reading the string, even if it could read
+more characters. The delimiter is extracted from the stream and then
+discarded. It will not appear in the final string. If you do not
+supply a <var class="var">delimiter</var>, always up to <var class="var">max-length</var> characters are
+read from the stream. The method returns the number of characters
+actually read from the stream.
+</p>
+<p>You can also read an <abbr class="acronym">STL</abbr> <code class="code">string</code> object from the
+stream, using an overloaded version of <code class="code">readString()</code>. The syntax
+is <code class="code">readString([<var class="var">delimiter</var>])</code>. You also do not need to
+supply a <var class="var">delimiter</var>, as it is set to &lsquo;<samp class="samp">\0</samp>&rsquo; by default (to
+prevent you from reading a virtually unlimited number of characters
+and flood your memory, since you can&rsquo;t supply a <var class="var">max-length</var>
+argument  this time). The method returns a <code class="code">string</code> object,
+containing all characters up to, but not including, <var class="var">delimiter</var> or
+the end of the stream, whichever was encountered first.
+</p>
+<a class="index-entry-id" id="index-Writing"></a>
+<p>All the above mentioned &ldquo;read&rdquo; methods have a &ldquo;write&rdquo; equivalent,
+with the same options and features. All &ldquo;write&rdquo; methods take the
+data to be written as first argument, as in (for example)
+<code class="code">writeInt(<var class="var">value</var>, <var class="var">size</var>)</code>, <var class="var">value</var> is the actual
+value to be written to the stream.
+</p>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Peeking.html">Peeking</a>, Previous: <a href="Files.html">Files</a>, Up: <a href="Usage.html">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Reference.html
+++ b/doc/libbinio/1.5/Reference.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Reference (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Reference (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Reference (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="FAQ.html" rel="next" title="FAQ">
+<link href="Usage.html" rel="prev" title="Usage">
+
+
+</head>
+
+<body lang="en">
+<div class="chapter-level-extent" id="Reference">
+<div class="nav-panel">
+<p>
+Next: <a href="FAQ.html" accesskey="n" rel="next">FAQ</a>, Previous: <a href="Usage.html" accesskey="p" rel="prev">Usage</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="chapter" id="Reference-1">3 Reference</h2>
+<a class="index-entry-id" id="index-Reference"></a>
+
+<p>This chapter comprises a complete reference of all classes, methods,
+types and variables inside libbinio.
+</p>
+
+<ul class="mini-toc">
+<li><a href="Concepts.html" accesskey="1">Concepts</a></li>
+<li><a href="Configuration.html" accesskey="2">Configuration</a></li>
+<li><a href="Base-classes.html" accesskey="3">Base classes</a></li>
+<li><a href="File-streams.html" accesskey="4">File streams</a></li>
+<li><a href="String-streams.html" accesskey="5">String streams</a></li>
+<li><a href="iostream-wrappers.html" accesskey="6">iostream wrappers</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Seeking.html
+++ b/doc/libbinio/1.5/Seeking.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Seeking (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Seeking (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Seeking (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Alien-architectures.html" rel="next" title="Alien architectures">
+<link href="Peeking.html" rel="prev" title="Peeking">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Seeking">
+<div class="nav-panel">
+<p>
+Next: <a href="Alien-architectures.html" accesskey="n" rel="next">Alien architectures</a>, Previous: <a href="Peeking.html" accesskey="p" rel="prev">Peeking</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Seeking-1">2.5 Seeking</h3>
+<a class="index-entry-id" id="index-Seeking"></a>
+<a class="index-entry-id" id="index-Positioning"></a>
+
+<p>Sometimes, you need to reposition within your stream. To do this, you
+use the <code class="code">seek(<var class="var">position</var>, [<var class="var">offset</var>])</code>
+method. <var class="var">position</var> is the new position in the stream, counted
+byte-wise and starting at &lsquo;<samp class="samp">0</samp>&rsquo;. The optional argument <var class="var">offset</var>
+specifies from where the method should seek. If it is &lsquo;<samp class="samp">Set</samp>&rsquo;,
+counting is started at the beginning of the stream. &lsquo;<samp class="samp">Add</samp>&rsquo;
+indicates to seek from the current stream position and &lsquo;<samp class="samp">End</samp>&rsquo;
+means seeking from the end of the stream. Note that <var class="var">position</var> is
+a signed integer value and you can also seek backwards by inserting a
+negative number.
+</p>
+<p>You can use the <code class="code">pos()</code> method to determine your current position
+within the stream, which is returned by the method.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/String-streams.html
+++ b/doc/libbinio/1.5/String-streams.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>String streams (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="String streams (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="String streams (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="iostream-wrappers.html" rel="next" title="iostream wrappers">
+<link href="File-streams.html" rel="prev" title="File streams">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="String-streams">
+<div class="nav-panel">
+<p>
+Next: <a href="iostream-wrappers.html" accesskey="n" rel="next">iostream wrappers</a>, Previous: <a href="File-streams.html" accesskey="p" rel="prev">File streams</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="String-streams-1">3.5 String streams</h3>
+<a class="index-entry-id" id="index-String-streams"></a>
+<a class="index-entry-id" id="index-binisstream"></a>
+<a class="index-entry-id" id="index-binosstream"></a>
+<a class="index-entry-id" id="index-binsstream"></a>
+<a class="index-entry-id" id="index-binsbase"></a>
+
+<p>The string stream classes provide a means of turning arbitrary strings
+(or &ldquo;blocks&rdquo;) in memory into a binary stream, similary to what
+<code class="code">strstream</code> does in the iostream library.
+</p>
+<p>Unlike <code class="code">strstream</code> from the iostream library, these streams
+<em class="emph">do not</em> support automatic enlarging of the memory area. If the
+user tries to write beyond the end of the stream, nothing is actually
+written and an <code class="code">Eof</code> error is issued.
+</p>
+<h4 class="subheading" id="Header-file_003a-binstr_002eh">Header file: <samp class="file">binstr.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-5">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binsbase_0028void-_002astr_002c-unsigned-long-len_0029'><span><code class="code">binsbase(void *str, unsigned long len)</code><a class="copiable-link" href='#index-binsbase_0028void-_002astr_002c-unsigned-long-len_0029'> &para;</a></span></dt>
+<dt id='index-binisstream_0028void-_002astr_002c-unsigned-long-len_0029'><span><code class="code">binisstream(void *str, unsigned long len)</code><a class="copiable-link" href='#index-binisstream_0028void-_002astr_002c-unsigned-long-len_0029'> &para;</a></span></dt>
+<dt id='index-binosstream_0028void-_002astr_002c-unsigned-long-len_0029'><span><code class="code">binosstream(void *str, unsigned long len)</code><a class="copiable-link" href='#index-binosstream_0028void-_002astr_002c-unsigned-long-len_0029'> &para;</a></span></dt>
+<dt id='index-binsstream_0028void-_002astr_002c-unsigned-long-len_0029'><span><code class="code">binsstream(void *str, unsigned long len)</code><a class="copiable-link" href='#index-binsstream_0028void-_002astr_002c-unsigned-long-len_0029'> &para;</a></span></dt>
+<dd><p>All constructors take two arguments. <code class="code">str</code> is a pointer to a
+previously initialized data string in memory. <code class="code">len</code> specifies the
+length in bytes of the string.
+</p>
+</dd>
+<dt id='index-_007ebinsbase_0028_0029'><span><code class="code">~binsbase()</code><a class="copiable-link" href='#index-_007ebinsbase_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinisstream_0028_0029'><span><code class="code">~binisstream()</code><a class="copiable-link" href='#index-_007ebinisstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinosstream_0028_0029'><span><code class="code">~binosstream()</code><a class="copiable-link" href='#index-_007ebinosstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinsstream_0028_0029'><span><code class="code">~binsstream()</code><a class="copiable-link" href='#index-_007ebinsstream_0028_0029'> &para;</a></span></dt>
+<dd><p>All deconstructors.
+</p>
+</dd>
+<dt id='index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029'><span><code class="code">virtual void seek(long pos, Offset offs = Set)</code><a class="copiable-link" href='#index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029'> &para;</a></span></dt>
+<dt id='index-virtual-long-pos_0028_0029-1'><span><code class="code">virtual long pos()</code><a class="copiable-link" href='#index-virtual-long-pos_0028_0029-1'> &para;</a></span></dt>
+<dd><p>Implementation of the abstract virtual methods, inherited from
+<code class="code">binio</code>. Refer to the reference of that class for more
+information.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-data-types-and-variables-in-binsbase_003a">Protected data types and variables in <code class="code">binsbase</code>:</h4>
+
+<dl class="vtable">
+<dt id='index-Byte-_002adata'><span><code class="code">Byte *data</code><a class="copiable-link" href='#index-Byte-_002adata'> &para;</a></span></dt>
+<dd><p>This pointer is always pointing to the beginning of the initialized
+data string in memory, passed to the constructor.
+</p></dd>
+<dt id='index-Byte-_002aspos'><span><code class="code">Byte *spos</code><a class="copiable-link" href='#index-Byte-_002aspos'> &para;</a></span></dt>
+<dd><p>This pointer points to the current position in the string stream.
+</p></dd>
+<dt id='index-long-length'><span><code class="code">long length</code><a class="copiable-link" href='#index-long-length'> &para;</a></span></dt>
+<dd><p>Holds the length in bytes for the whole data string in memory, as
+passed to the constructor.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="iostream-wrappers.html">iostream wrappers</a>, Previous: <a href="File-streams.html">File streams</a>, Up: <a href="Reference.html">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Type-Variable-and-Macro-Index.html
+++ b/doc/libbinio/1.5/Type-Variable-and-Macro-Index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Type Variable and Macro Index (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Type Variable and Macro Index (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Type Variable and Macro Index (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Method-Index.html" rel="prev" title="Method Index">
+<style type="text/css">
+<!--
+a.summary-letter-printindex {text-decoration: none}
+td.printindex-index-entry {vertical-align: top}
+td.printindex-index-section {vertical-align: top}
+th.entries-header-printindex {text-align:left}
+th.sections-header-printindex {text-align:left}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="unnumbered-level-extent" id="Type-Variable-and-Macro-Index">
+<div class="nav-panel">
+<p>
+Previous: <a href="Method-Index.html" accesskey="p" rel="prev">Method Index</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="unnumbered" id="Type_002c-Variable-and-Macro-Index">Type, Variable and Macro Index</h2>
+
+<div class="printindex vr-printindex">
+<table class="vr-letters-header-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-A"><b>A</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-D"><b>D</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-L"><b>L</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-M"><b>M</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-N"><b>N</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-U"><b>U</b></a>
+ &nbsp; 
+</td></tr></table>
+<table class="vr-entries-printindex" border="0">
+<tr><td></td><th class="entries-header-printindex">Index Entry</th><td>&nbsp;</td><th class="sections-header-printindex"> Section</th></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-A">A</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Add"><code>Add</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-Append"><code>Append</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-B">B</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-BigEndian"><code>BigEndian</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-BINIO_005fENABLE_005fIOSTREAM"><code>BINIO_ENABLE_IOSTREAM</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-BINIO_005fENABLE_005fSTRING"><code>BINIO_ENABLE_STRING</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-BINIO_005fISO_005fSTDLIB"><code>BINIO_ISO_STDLIB</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="Configuration.html#index-BINIO_005fWITH_005fMATH"><code>BINIO_WITH_MATH</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="Configuration.html">Configuration</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Byte"><code>Byte</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-Byte-_002adata"><code>Byte *data</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-Byte-_002aspos"><code>Byte *spos</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-D">D</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Denied"><code>Denied</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Double"><code>Double</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-E">E</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-End"><code>End</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-enum-ErrorCode"><code>enum ErrorCode</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-enum-Flag"><code>enum Flag</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-enum-FType"><code>enum FType</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-enum-ModeFlags"><code>enum ModeFlags</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-enum-Offset"><code>enum Offset</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Eof"><code>Eof</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Error-err"><code>Error err</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-F">F</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Fatal"><code>Fatal</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-FILE-_002af"><code>FILE *f</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Flags-1"><code>Flags</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Flags-my_005fflags"><code>Flags my_flags</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Float"><code>Float</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-FloatIEEE"><code>FloatIEEE</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-I">I</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Int"><code>Int</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-int-Error"><code>int Error</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-L">L</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="String-streams.html#index-long-length"><code>long length</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="String-streams.html">String streams</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-M">M</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-Mode"><code>Mode</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-N">N</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binfbase.html#index-NoCreate"><code>NoCreate</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binfbase.html">binfbase</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-NoError"><code>NoError</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-NotFound"><code>NotFound</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-NotOpen"><code>NotOpen</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-S">S</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Set"><code>Set</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Single"><code>Single</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-static-const-Flags-system_005fflags"><code>static const Flags system_flags</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+<tr><th id="Type-Variable-and-Macro-Index_vr_letter-U">U</th><td></td><td></td></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="binio.html#index-Unsupported"><code>Unsupported</code></a>:</td><td>&nbsp;</td><td class="printindex-index-section"><a href="binio.html">binio</a></td></tr>
+<tr><td colspan="4"> <hr></td></tr>
+</table>
+<table class="vr-letters-footer-printindex"><tr><th>Jump to: &nbsp; </th><td><a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-A"><b>A</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-B"><b>B</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-D"><b>D</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-E"><b>E</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-F"><b>F</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-I"><b>I</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-L"><b>L</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-M"><b>M</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-N"><b>N</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-S"><b>S</b></a>
+ &nbsp; 
+<a class="summary-letter-printindex" href="#Type-Variable-and-Macro-Index_vr_letter-U"><b>U</b></a>
+ &nbsp; 
+</td></tr></table>
+</div>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Previous: <a href="Method-Index.html">Method Index</a>, Up: <a href="index.html">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Usage.html
+++ b/doc/libbinio/1.5/Usage.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Usage (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Usage (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Usage (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="index.html" rel="up" title="Top">
+<link href="Reference.html" rel="next" title="Reference">
+<link href="Introduction.html" rel="prev" title="Introduction">
+
+
+</head>
+
+<body lang="en">
+<div class="chapter-level-extent" id="Usage">
+<div class="nav-panel">
+<p>
+Next: <a href="Reference.html" accesskey="n" rel="next">Reference</a>, Previous: <a href="Introduction.html" accesskey="p" rel="prev">Introduction</a>, Up: <a href="index.html" accesskey="u" rel="up">Binary I/O stream class library</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h2 class="chapter" id="Usage-1">2 Usage</h2>
+<a class="index-entry-id" id="index-Usage"></a>
+
+<p>This chapter covers common usage of libbinio and mostly everything you
+need to know to interface with the library. For very advanced usage,
+refer to <a class="ref" href="Reference.html">Reference</a>.
+</p>
+<p>Since libbinio&rsquo;s class framework is modelled somewhat after the
+traditional iostream library, it is good if you already have used the
+C++ iostream facility before.
+</p>
+
+<ul class="mini-toc">
+<li><a href="Basics.html" accesskey="1">Basics</a></li>
+<li><a href="Files.html" accesskey="2">Files</a></li>
+<li><a href="Reading-and-Writing.html" accesskey="3">Reading and Writing</a></li>
+<li><a href="Peeking.html" accesskey="4">Peeking</a></li>
+<li><a href="Seeking.html" accesskey="5">Seeking</a></li>
+<li><a href="Alien-architectures.html" accesskey="6">Alien architectures</a></li>
+<li><a href="Wrapping-around-iostream.html" accesskey="7">Wrapping around iostream</a></li>
+<li><a href="Errors.html" accesskey="8">Errors</a></li>
+<li><a href="Creating-architecture_002dindependent-file-formats.html" accesskey="9">Creating architecture-independent file formats</a></li>
+<li><a href="Examples.html">Examples</a></li>
+</ul>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/Wrapping-around-iostream.html
+++ b/doc/libbinio/1.5/Wrapping-around-iostream.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Wrapping around iostream (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Wrapping around iostream (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Wrapping around iostream (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Usage.html" rel="up" title="Usage">
+<link href="Errors.html" rel="next" title="Errors">
+<link href="Alien-architectures.html" rel="prev" title="Alien architectures">
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="Wrapping-around-iostream">
+<div class="nav-panel">
+<p>
+Next: <a href="Errors.html" accesskey="n" rel="next">Errors</a>, Previous: <a href="Alien-architectures.html" accesskey="p" rel="prev">Alien architectures</a>, Up: <a href="Usage.html" accesskey="u" rel="up">Usage</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="Wrapping-around-iostream-1">2.7 Wrapping around iostream</h3>
+<a class="index-entry-id" id="index-Wrapping-around-iostream"></a>
+<a class="index-entry-id" id="index-iostream-wrappers"></a>
+
+<p>libbinio provides a set of classes, called <code class="code">binwstream</code>,
+<code class="code">biniwstream</code> and <code class="code">binowstream</code>, that can be wrapped around
+an already existing stream from the standard or traditional C++
+iostream library.
+</p>
+<p>To do this, you just have to pass a pointer to the original stream
+object from the iostream library to the constructor of the appropriate
+<code class="code">binwstream</code> class. Of course, you have to match an input stream
+from the iostream library to an input stream from libbinio and
+analogous for the output-only streams. The class framework will
+prevent you from mismatching them. You can, however, wrap an
+unidirectional binary stream around a bidirectional stream from the
+iostream library.
+</p>
+<p>There is one important thing you have to remember: If you plan to wrap
+a binary stream around an iostream stream, always open the iostream
+stream with the <code class="code">ios::bin</code> mode flag set! This will prevent some
+operating systems (namely, MS-DOS and Windows) from doing nasty
+implicit interpretation on the streams. This definitly will impose
+problems when you try to read or write the binary stream.
+</p>
+<p>All other flags, you set when opening the original iostream stream,
+can indirectly have effect on the operations you do on the wrapped
+binary stream.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/binfbase.html
+++ b/doc/libbinio/1.5/binfbase.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>binfbase (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="binfbase (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="binfbase (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="File-streams.html" rel="up" title="File streams">
+<link href="File-stream-classes.html" rel="next" title="File stream classes">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="binfbase">
+<div class="nav-panel">
+<p>
+Next: <a href="File-stream-classes.html" accesskey="n" rel="next">File stream classes</a>, Up: <a href="File-streams.html" accesskey="u" rel="up">File streams</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="binfbase-1">3.4.1 binfbase</h4>
+<a class="index-entry-id" id="index-binfbase"></a>
+
+<p><code class="code">binfbase</code> provides the common base class for all file I/O binary
+streams. It defines important data types, variables and methods.
+</p>
+<h4 class="subheading" id="Header-file_003a-binfile_002eh">Header file: <samp class="file">binfile.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-3">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binfbase_0028_0029'><span><code class="code">binfbase()</code><a class="copiable-link" href='#index-binfbase_0028_0029'> &para;</a></span></dt>
+<dd><p>The constructor.
+</p>
+</dd>
+<dt id='index-_007ebinfbase_0028_0029'><span><code class="code">~binfbase()</code><a class="copiable-link" href='#index-_007ebinfbase_0028_0029'> &para;</a></span></dt>
+<dd><p>The destructor. Automatically closes an eventually open stream.
+</p>
+</dd>
+<dt id='index-virtual-void-open_0028const-char-_002afilename_002c-const-Mode-mode_0029'><span><code class="code">virtual void open(const char *filename, const Mode mode)</code><a class="copiable-link" href='#index-virtual-void-open_0028const-char-_002afilename_002c-const-Mode-mode_0029'> &para;</a></span></dt>
+<dt id='index-virtual-void-open_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode_0029'><span><code class="code">virtual void open(const std::string &amp;filename, const Mode mode)</code><a class="copiable-link" href='#index-virtual-void-open_0028const-std_003a_003astring-_0026filename_002c-const-Mode-mode_0029'> &para;</a></span></dt>
+<dd><p>Two versions of an abstract virtual method to open a binary file
+stream. <code class="code">filename</code> is the filename of the file to open and
+<code class="code">mode</code> specifies in which mode to do so. Refer to the list of
+data types for this class for more information on this argument. You
+can combine multiple mode flags together, using the &lsquo;<samp class="samp">|</samp>&rsquo;
+operator.
+</p>
+</dd>
+<dt id='index-void-close_0028_0029'><span><code class="code">void close()</code><a class="copiable-link" href='#index-void-close_0028_0029'> &para;</a></span></dt>
+<dd><p>Method to explicitly close the stream.
+</p>
+</dd>
+<dt id='index-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029'><span><code class="code">void seek(long pos, Offset offs = Set)</code><a class="copiable-link" href='#index-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029'> &para;</a></span></dt>
+<dt id='index-long-pos_0028_0029'><span><code class="code">long pos()</code><a class="copiable-link" href='#index-long-pos_0028_0029'> &para;</a></span></dt>
+<dd><p>Implementation of the abstract virtual methods, inherited from
+<code class="code">binio</code>. Look there for reference.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Public-data-types-and-variables_003a-1">Public data types and variables:</h4>
+
+<dl class="vtable">
+<dt id='index-enum-ModeFlags'><span><code class="code">enum ModeFlags</code><a class="copiable-link" href='#index-enum-ModeFlags'> &para;</a></span></dt>
+<dd><p>Enumeration of all defined file stream open mode flags, defining how a
+file should be opened when the <code class="code">open()</code> method is called. This
+type defines the following flags:
+</p>
+<dl class="vtable">
+<dt id='index-Append'><span><code class="code">Append</code><a class="copiable-link" href='#index-Append'> &para;</a></span></dt>
+<dd><p>Open the stream for appending. The stream pointer is positioned at the
+end of the stream. Also, do not truncate a file to zero length, if it
+already exists.
+</p></dd>
+<dt id='index-NoCreate'><span><code class="code">NoCreate</code><a class="copiable-link" href='#index-NoCreate'> &para;</a></span></dt>
+<dd><p>Do not automatically create a nonexistant file on first access and
+fail instead. Also, do not truncate a file to zero length, if it
+already exists.
+</p></dd>
+</dl>
+
+</dd>
+<dt id='index-Mode'><span><code class="code">Mode</code><a class="copiable-link" href='#index-Mode'> &para;</a></span></dt>
+<dd><p>Type of the variable to hold the mode specification flags that are
+passed to one of the <code class="code">open()</code> methods to open a file
+stream. Refer to <code class="code">enum ModeFlags</code> above for information on what
+flags are defined.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-data-types-and-variables_003a-1">Protected data types and variables:</h4>
+
+<dl class="vtable">
+<dt id='index-FILE-_002af'><span><code class="code">FILE *f</code><a class="copiable-link" href='#index-FILE-_002af'> &para;</a></span></dt>
+<dd><p>Pointer to the currently opened file of this stream.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="File-stream-classes.html">File stream classes</a>, Up: <a href="File-streams.html">File streams</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/binio.html
+++ b/doc/libbinio/1.5/binio.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>binio (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="binio (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="binio (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Base-classes.html" rel="up" title="Base classes">
+<link href="binistream.html" rel="next" title="binistream">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="binio">
+<div class="nav-panel">
+<p>
+Next: <a href="binistream.html" accesskey="n" rel="next">binistream</a>, Up: <a href="Base-classes.html" accesskey="u" rel="up">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="binio-1">3.3.1 binio</h4>
+<a class="index-entry-id" id="index-binio"></a>
+
+<p><code class="code">binio</code> is the general base class, containing important method,
+type and variable declarations. As a user, you normally do not need it
+directly, except for scoping types and variables to it.
+</p>
+<h4 class="subheading" id="Header-file_003a-binio_002eh">Header file: <samp class="file">binio.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binio_0028_0029'><span><code class="code">binio()</code><a class="copiable-link" href='#index-binio_0028_0029'> &para;</a></span></dt>
+<dd><p>The constructor.
+</p>
+</dd>
+<dt id='index-_007ebinio_0028_0029'><span><code class="code">~binio()</code><a class="copiable-link" href='#index-_007ebinio_0028_0029'> &para;</a></span></dt>
+<dd><p>The destructor.
+</p>
+</dd>
+<dt id='index-void-setFlag_0028Flag-f_002c-bool-set-_003d-true_0029'><span><code class="code">void setFlag(Flag f, bool set = true)</code><a class="copiable-link" href='#index-void-setFlag_0028Flag-f_002c-bool-set-_003d-true_0029'> &para;</a></span></dt>
+<dd><p>Is used to set or erase flags to change the behaviour of the
+stream. Available flags and their meaning are listed in the types
+table for this class, below. The optional argument <code class="code">set</code> is used
+to set or erase the specified flag. If it is not specified, it
+defaults to <code class="code">true</code>, setting (activating) the specified flag.
+</p>
+</dd>
+<dt id='index-bool-getFlag_0028Flag-f_0029'><span><code class="code">bool getFlag(Flag f)</code><a class="copiable-link" href='#index-bool-getFlag_0028Flag-f_0029'> &para;</a></span></dt>
+<dd><p>Returns whether the specified flag is set (active) or not. Refer to
+<code class="code">setFlag</code>, above, for more information.
+</p>
+</dd>
+<dt id='index-Error-error_0028_0029'><span><code class="code">Error error()</code><a class="copiable-link" href='#index-Error-error_0028_0029'> &para;</a></span></dt>
+<dd><p>Returns the current error status of the stream. A status of no error
+is always indicated with a value of &lsquo;<samp class="samp">0</samp>&rsquo;, as to allow easy error
+checks with a simple <code class="code">if</code> construct.
+</p>
+</dd>
+<dt id='index-bool-eof_0028_0029'><span><code class="code">bool eof()</code><a class="copiable-link" href='#index-bool-eof_0028_0029'> &para;</a></span></dt>
+<dd><p>Returns &lsquo;<samp class="samp">true</samp>&rsquo; if the last access to the stream was unsuccessful
+because the stream pointer was already past the end of the
+stream. &lsquo;<samp class="samp">false</samp>&rsquo; is returned otherwise. Synonymous to checking if
+the return value of a call to <code class="code">error()</code> sets the <code class="code">Eof</code> error
+code flag.
+</p>
+</dd>
+<dt id='index-virtual-void-seek_0028long_002c-Offset-_003d-Set_0029'><span><code class="code">virtual void seek(long, Offset = Set)</code><a class="copiable-link" href='#index-virtual-void-seek_0028long_002c-Offset-_003d-Set_0029'> &para;</a></span></dt>
+<dd><p>Abstract virtual method for seeking into streams. Implemented by the
+stream layer. The first argument specifies the relative position to
+seek to. Use a negative value to seek backwards. The optional second
+argument specifies from where to start seeking. <code class="code">Set</code> specifies
+the beginning of a stream, <code class="code">Add</code> specifies the current position
+and <code class="code">End</code> specifies the end of the stream. If it is omitted, it
+defaults to <code class="code">Set</code>, seeking from the beginning of the stream.
+</p>
+</dd>
+<dt id='index-virtual-long-pos_0028_0029'><span><code class="code">virtual long pos()</code><a class="copiable-link" href='#index-virtual-long-pos_0028_0029'> &para;</a></span></dt>
+<dd><p>Abstract virtual method that returns the current position inside the
+stream. Implemented by the stream layer.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-methods_003a">Protected methods:</h4>
+
+<dl class="ftable">
+<dt id='index-Float-pow_0028Float-base_002c-signed-int-exp_0029'><span><code class="code">Float pow(Float base, signed int exp)</code><a class="copiable-link" href='#index-Float-pow_0028Float-base_002c-signed-int-exp_0029'> &para;</a></span></dt>
+<dd><p>Is a stripped-down version of the <code class="code">pow()</code> function from the
+<samp class="file">math.h</samp> standard C math library include file. It is used during
+conversion between floating-point formats and can calculate powers of
+a floating-point base argument, using a signed integer exponent.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Public-data-types-and-variables_003a">Public data types and variables:</h4>
+
+<dl class="vtable">
+<dt id='index-enum-Flag'><span><code class="code">enum Flag</code><a class="copiable-link" href='#index-enum-Flag'> &para;</a></span></dt>
+<dd><p>Enumeration of all defined stream flags that can be set using the
+<code class="code">setFlag()</code> and <code class="code">getFlag()</code> methods. This type defines the
+following values:
+</p>
+<dl class="vtable">
+<dt id='index-BigEndian'><span><code class="code">BigEndian</code><a class="copiable-link" href='#index-BigEndian'> &para;</a></span></dt>
+<dd><p>If set, sets the stream&rsquo;s byte-ordering to big endian
+notation. Otherwise, little endian notation is used.
+</p>
+</dd>
+<dt id='index-FloatIEEE'><span><code class="code">FloatIEEE</code><a class="copiable-link" href='#index-FloatIEEE'> &para;</a></span></dt>
+<dd><p>If set, all floating-point access to the stream will assume
+<abbr class="acronym">IEEE-754</abbr> standardized floating-point numbers. Only this type
+of data is expected from and written to the stream.
+</p>
+<p>If your architecture does not support <abbr class="acronym">IEEE-754</abbr>
+floating-point numbers, the value will be converted. Various
+conversion errors can occur and sometimes the conversion is not
+possible at all. In this case, the <code class="code">Unsupported</code> error is issued
+and a specific value is returned. The following table summarizes all
+possible return codes for certain problematic values:
+</p>
+<table class="multitable">
+<tbody><tr><td>Real value</td><td>Return value</td></tr>
+<tr><td>&lsquo;<samp class="samp">Infinity</samp>&rsquo;</td><td>&lsquo;<samp class="samp">1.0</samp>&rsquo;</td></tr>
+<tr><td>&lsquo;<samp class="samp">-Infinity</samp>&rsquo;</td><td>&lsquo;<samp class="samp">-1.0</samp>&rsquo;</td></tr>
+<tr><td>&lsquo;<samp class="samp">Not a Number (NaN)</samp>&rsquo;</td><td>&lsquo;<samp class="samp">0.0</samp>&rsquo;</td></tr>
+</tbody>
+</table>
+
+<p>Both positive and negative zero (&lsquo;<samp class="samp">0</samp>&rsquo;) are mapped to the same zero
+value, if your architecture does not support both positive and
+negative zeroes. There is no way to distinguish between the two values
+in this case.
+</p>
+</dd>
+</dl>
+
+</dd>
+<dt id='index-enum-ErrorCode'><span><code class="code">enum ErrorCode</code><a class="copiable-link" href='#index-enum-ErrorCode'> &para;</a></span></dt>
+<dd><p>Enumeration of all possible error values. This type defines the
+following values:
+</p>
+<dl class="vtable">
+<dt id='index-NoError'><span><code class="code">NoError</code><a class="copiable-link" href='#index-NoError'> &para;</a></span></dt>
+<dd><p>No error at all. This is always mapped to an integer value of
+&lsquo;<samp class="samp">0</samp>&rsquo;.
+</p>
+</dd>
+<dt id='index-Fatal'><span><code class="code">Fatal</code><a class="copiable-link" href='#index-Fatal'> &para;</a></span></dt>
+<dd><p>An unspecified, fatal error occured. This error is issued only if
+something really strange happened (i.e. on internal logic errors in
+the library, or if something else, undefined happens, etc.). It is
+advised to immediately terminate any binary stream I/O activity and
+fail with an error message to the application user, maybe even
+terminate the application completely.
+</p>
+</dd>
+<dt id='index-Unsupported'><span><code class="code">Unsupported</code><a class="copiable-link" href='#index-Unsupported'> &para;</a></span></dt>
+<dd><p>You tried to access stream data in an unsupported way. This error is
+issued whenever an (explicit or implicit) conversion between two types
+of data storage is requested, that isn&rsquo;t supported by libbinio yet.
+</p>
+</dd>
+<dt id='index-NotOpen'><span><code class="code">NotOpen</code><a class="copiable-link" href='#index-NotOpen'> &para;</a></span></dt>
+<dd><p>The stream you tried to access is not open yet.
+</p>
+</dd>
+<dt id='index-Denied'><span><code class="code">Denied</code><a class="copiable-link" href='#index-Denied'> &para;</a></span></dt>
+<dd><p>Access to this stream is denied. This error is normally issued when
+you try to open a file on a filesystem, but you have insufficient
+rights to access it.
+</p>
+</dd>
+<dt id='index-NotFound'><span><code class="code">NotFound</code><a class="copiable-link" href='#index-NotFound'> &para;</a></span></dt>
+<dd><p>The stream you tried to access was not found. This is mostly issued
+on a file not found error, when accessing normal files on a
+filesystem.
+</p>
+</dd>
+<dt id='index-Eof'><span><code class="code">Eof</code><a class="copiable-link" href='#index-Eof'> &para;</a></span></dt>
+<dd><p>The end of the stream has been passed. Issued when you tried to read
+past the last byte of a stream.
+</p></dd>
+</dl>
+
+</dd>
+<dt id='index-enum-Offset'><span><code class="code">enum Offset</code><a class="copiable-link" href='#index-enum-Offset'> &para;</a></span></dt>
+<dd><p>Specifies the position inside a stream, from where a seek is started
+with the <code class="code">seek()</code> method. This type defines the following values:
+</p>
+<dl class="vtable">
+<dt id='index-Set'><span><code class="code">Set</code><a class="copiable-link" href='#index-Set'> &para;</a></span></dt>
+<dd><p>Start seeking at the beginning of the stream.
+</p>
+</dd>
+<dt id='index-Add'><span><code class="code">Add</code><a class="copiable-link" href='#index-Add'> &para;</a></span></dt>
+<dd><p>Start seeking from the current position in the stream.
+</p>
+</dd>
+<dt id='index-End'><span><code class="code">End</code><a class="copiable-link" href='#index-End'> &para;</a></span></dt>
+<dd><p>Start seeking from the end of the stream.
+</p></dd>
+</dl>
+
+</dd>
+<dt id='index-enum-FType'><span><code class="code">enum FType</code><a class="copiable-link" href='#index-enum-FType'> &para;</a></span></dt>
+<dd><p>Specifies what type of floating-point number is to be accessed next,
+using the <code class="code">readFloat()</code> or <code class="code">writeFloat()</code> methods. Most
+floating-point formats specify multiple data types to support a
+broader range of precision. libbinio generalizes the idea by
+categorizing them only into single and double precision numbers. This
+type defines the following values:
+</p>
+<dl class="vtable">
+<dt id='index-Single'><span><code class="code">Single</code><a class="copiable-link" href='#index-Single'> &para;</a></span></dt>
+<dd><p>Access a single precision floating-point number.
+</p>
+</dd>
+<dt id='index-Double'><span><code class="code">Double</code><a class="copiable-link" href='#index-Double'> &para;</a></span></dt>
+<dd><p>Access a double precision floating-point number.
+</p></dd>
+</dl>
+
+</dd>
+<dt id='index-int-Error'><span><code class="code">int Error</code><a class="copiable-link" href='#index-int-Error'> &para;</a></span></dt>
+<dd><p>This integer holds a bit field of all error values for a
+stream. Returned by <code class="code">error()</code>. A status of &ldquo;no error&rdquo; is always
+indicated when the whole field is set to &lsquo;<samp class="samp">0</samp>&rsquo; (zero), i.e. the
+integer is &lsquo;<samp class="samp">0</samp>&rsquo;. Test for an error by binary or&rsquo;ing this integer
+with one of the error values from <code class="code">ErrorCode</code>.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-data-types-and-variables_003a">Protected data types and variables:</h4>
+
+<dl class="vtable">
+<dt id='index-Int'><span><code class="code">Int</code><a class="copiable-link" href='#index-Int'> &para;</a></span></dt>
+<dd><p>The largest integer type supported by the architecture.
+</p>
+</dd>
+<dt id='index-Float'><span><code class="code">Float</code><a class="copiable-link" href='#index-Float'> &para;</a></span></dt>
+<dd><p>The largest floating-point type supported by the architecture.
+</p>
+</dd>
+<dt id='index-Byte'><span><code class="code">Byte</code><a class="copiable-link" href='#index-Byte'> &para;</a></span></dt>
+<dd><p>This type is always one byte (8 bits) wide.
+</p>
+</dd>
+<dt id='index-Flags-1'><span><code class="code">Flags</code><a class="copiable-link" href='#index-Flags-1'> &para;</a></span></dt>
+<dd><p>Type to hold a flag variable, containing the status of all flags of a
+stream.
+</p>
+</dd>
+<dt id='index-Flags-my_005fflags'><span><code class="code">Flags my_flags</code><a class="copiable-link" href='#index-Flags-my_005fflags'> &para;</a></span></dt>
+<dd><p>This variable holds the current status of all flags for the stream.
+</p>
+</dd>
+<dt id='index-static-const-Flags-system_005fflags'><span><code class="code">static const Flags system_flags</code><a class="copiable-link" href='#index-static-const-Flags-system_005fflags'> &para;</a></span></dt>
+<dd><p>This variable holds the status of the flags, defining the standard
+behaviour of the system. This is determined once at runtime, at
+startup of the library.
+</p>
+</dd>
+<dt id='index-Error-err'><span><code class="code">Error err</code><a class="copiable-link" href='#index-Error-err'> &para;</a></span></dt>
+<dd><p>This variable holds the error status of a stream.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="binistream.html">binistream</a>, Up: <a href="Base-classes.html">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/binistream.html
+++ b/doc/libbinio/1.5/binistream.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>binistream (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="binistream (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="binistream (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Base-classes.html" rel="up" title="Base classes">
+<link href="binostream.html" rel="next" title="binostream">
+<link href="binio.html" rel="prev" title="binio">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="binistream">
+<div class="nav-panel">
+<p>
+Next: <a href="binostream.html" accesskey="n" rel="next">binostream</a>, Previous: <a href="binio.html" accesskey="p" rel="prev">binio</a>, Up: <a href="Base-classes.html" accesskey="u" rel="up">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="binistream-1">3.3.2 binistream</h4>
+<a class="index-entry-id" id="index-binistream"></a>
+
+<p><code class="code">binistream</code> provides an input-only binary stream.
+</p>
+<h4 class="subheading" id="Header-file_003a-binio_002eh-1">Header file: <samp class="file">binio.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-1">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binistream_0028_0029'><span><code class="code">binistream()</code><a class="copiable-link" href='#index-binistream_0028_0029'> &para;</a></span></dt>
+<dd><p>The constructor.
+</p>
+</dd>
+<dt id='index-_007ebinistream_0028_0029'><span><code class="code">~binistream()</code><a class="copiable-link" href='#index-_007ebinistream_0028_0029'> &para;</a></span></dt>
+<dd><p>The destructor.
+</p>
+</dd>
+<dt id='index-Int-readInt_0028unsigned-int-size_0029'><span><code class="code">Int readInt(unsigned int size)</code><a class="copiable-link" href='#index-Int-readInt_0028unsigned-int-size_0029'> &para;</a></span></dt>
+<dd><p>Reads an integer of size <code class="code">size</code> (in bytes) from the stream and
+returns it. The return value is undefined if an error occured. The
+maximum number of bytes that can be read at once equals the size (in
+bytes) of the largest integer type, supported by the system.
+</p>
+</dd>
+<dt id='index-Float-readFloat_0028FType-ft_0029'><span><code class="code">Float readFloat(FType ft)</code><a class="copiable-link" href='#index-Float-readFloat_0028FType-ft_0029'> &para;</a></span></dt>
+<dd><p>Reads a floating-point number from the stream and returns it. Takes
+the floating-point format to read as the argument <code class="code">ft</code>. Refer to
+the list of public types of the <code class="code">binio</code> class for information
+about what floating-point formats are supported. The return value is
+undefined if an error occured. The value from the stream is always
+rendered to the biggest floating-point type, supported by the system.
+</p>
+<p>If your architecture is incompatible with the floating-point number
+that has just been read, <code class="code">readFloat()</code> tries to convert it. This
+is sometimes not possible or not as accurate as the original value and
+an error will be issued in these cases. Refer to the list of public
+types of the <code class="code">binio</code> class for information about what errors
+could be issued.
+</p>
+</dd>
+<dt id='index-unsigned-long-readString_0028char-_002astr_002c-unsigned-long-maxlen_002c-const-char-delim_0029'><span><code class="code">unsigned long readString(char *str, unsigned long maxlen, const char delim)</code><a class="copiable-link" href='#index-unsigned-long-readString_0028char-_002astr_002c-unsigned-long-maxlen_002c-const-char-delim_0029'> &para;</a></span></dt>
+<dt id='index-std_003a_003astring-readString_0028const-char-delim-_003d-_0027_005c0_0027_0029'><span><code class="code">std::string readString(const char delim = '\0')</code><a class="copiable-link" href='#index-std_003a_003astring-readString_0028const-char-delim-_003d-_0027_005c0_0027_0029'> &para;</a></span></dt>
+<dd><p>Reads a character string from the stream. Both pre-allocated standard
+C <abbr class="acronym">ASCIIZ</abbr> strings and <abbr class="acronym">STL</abbr> <code class="code">string</code> objects are
+supported.
+</p>
+<p>The <abbr class="acronym">ASCIIZ</abbr> version takes a pointer to the pre-allocated
+string buffer as the <code class="code">str</code> argument. <code class="code">maxlen</code> specifies the
+maximum number of characters to be read from the stream (<em class="emph">not</em>
+including the trailing &lsquo;<samp class="samp">\0</samp>&rsquo; that is always appended to the string
+buffer). The optional argument <code class="code">delim</code> is a delimiter
+character. If this character is encountered in the stream, no more
+characters will be read. The delimiter character itself is
+discarded. It will not appear in the final string. If the <code class="code">delim</code>
+argument is omitted, always up to <code class="code">maxlen</code> characters are read.
+</p>
+<p>The <code class="code">string</code> object version just takes one optional argument, the
+delimiter character, explained above. Characters are always read until
+the delimiter character or the end of the stream is encountered. If
+<code class="code">delim</code> is omitted, it defaults to &lsquo;<samp class="samp">\0</samp>&rsquo;. It returns a
+<code class="code">string</code> object, containing the final string.
+</p>
+</dd>
+<dt id='index-Int-peekInt_0028unsigned-int-size_0029'><span><code class="code">Int peekInt(unsigned int size)</code><a class="copiable-link" href='#index-Int-peekInt_0028unsigned-int-size_0029'> &para;</a></span></dt>
+<dd><p>Like <code class="code">readInt()</code>, but doesn&rsquo;t modify the stream position, so any
+later access to the stream will appear as if <code class="code">peekInt()</code> has
+never been called.
+</p>
+</dd>
+<dt id='index-Float-peekFloat_0028FType-ft_0029'><span><code class="code">Float peekFloat(FType ft)</code><a class="copiable-link" href='#index-Float-peekFloat_0028FType-ft_0029'> &para;</a></span></dt>
+<dd><p>Like <code class="code">readFloat()</code>, but doesn&rsquo;t modify the stream position, so
+any later access to the stream will appear as if <code class="code">peekFloat()</code>
+has never been called.
+</p>
+</dd>
+<dt id='index-bool-ateof_0028_0029'><span><code class="code">bool ateof()</code><a class="copiable-link" href='#index-bool-ateof_0028_0029'> &para;</a></span></dt>
+<dd><p>Returns &lsquo;<samp class="samp">true</samp>&rsquo; if the current stream position is at the last byte
+of the stream. &lsquo;<samp class="samp">false</samp>&rsquo; is returned otherwise.
+</p>
+</dd>
+<dt id='index-void-ignore_0028unsigned-long-amount-_003d-1_0029'><span><code class="code">void ignore(unsigned long amount = 1)</code><a class="copiable-link" href='#index-void-ignore_0028unsigned-long-amount-_003d-1_0029'> &para;</a></span></dt>
+<dd><p>Reads and then immediately discards the specified amount of bytes from
+the stream. If the optional argument <code class="code">amount</code> is omitted, it
+defaults to &lsquo;<samp class="samp">1</samp>&rsquo;, ignoring exactly 1 byte from the stream.
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-methods_003a-1">Protected methods:</h4>
+
+<dl class="ftable">
+<dt id='index-virtual-Byte-getByte_0028_0029'><span><code class="code">virtual Byte getByte()</code><a class="copiable-link" href='#index-virtual-Byte-getByte_0028_0029'> &para;</a></span></dt>
+<dd><p>Abstract virtual method to extract exactly one byte (8 bits) from the
+stream and advance stream pointer accordingly. The byte is
+returned. Implemented by the stream layer.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="binostream.html">binostream</a>, Previous: <a href="binio.html">binio</a>, Up: <a href="Base-classes.html">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/binostream.html
+++ b/doc/libbinio/1.5/binostream.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>binostream (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="binostream (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="binostream (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Base-classes.html" rel="up" title="Base classes">
+<link href="binstream.html" rel="next" title="binstream">
+<link href="binistream.html" rel="prev" title="binistream">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="binostream">
+<div class="nav-panel">
+<p>
+Next: <a href="binstream.html" accesskey="n" rel="next">binstream</a>, Previous: <a href="binistream.html" accesskey="p" rel="prev">binistream</a>, Up: <a href="Base-classes.html" accesskey="u" rel="up">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="binostream-1">3.3.3 binostream</h4>
+<a class="index-entry-id" id="index-binostream"></a>
+
+<p><code class="code">binostream</code> provides an output-only binary stream.
+</p>
+<h4 class="subheading" id="Header-file_003a-binio_002eh-2">Header file: <samp class="file">binio.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-2">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-binostream_0028_0029'><span><code class="code">binostream()</code><a class="copiable-link" href='#index-binostream_0028_0029'> &para;</a></span></dt>
+<dd><p>The constructor.
+</p>
+</dd>
+<dt id='index-_007ebinostream_0028_0029'><span><code class="code">~binostream()</code><a class="copiable-link" href='#index-_007ebinostream_0028_0029'> &para;</a></span></dt>
+<dd><p>The destructor.
+</p>
+</dd>
+<dt id='index-void-writeInt_0028Int-val_002c-unsigned-int-size_0029_003b'><span><code class="code">void writeInt(Int val, unsigned int size);</code><a class="copiable-link" href='#index-void-writeInt_0028Int-val_002c-unsigned-int-size_0029_003b'> &para;</a></span></dt>
+<dd><p>Writes the integer value <code class="code">val</code> of size <code class="code">size</code> (in bytes) to
+the stream.
+</p>
+</dd>
+<dt id='index-void-writeFloat_0028Float-f_002c-FType-ft_0029_003b'><span><code class="code">void writeFloat(Float f, FType ft);</code><a class="copiable-link" href='#index-void-writeFloat_0028Float-f_002c-FType-ft_0029_003b'> &para;</a></span></dt>
+<dd><p>Writes the floating-point value <code class="code">f</code> of type <code class="code">ft</code> to the
+stream. Refer to the list of public types of the <code class="code">binio</code> class
+for information about what floating-point formats are supported.
+</p>
+<p>If the requested floating-point type is not supported by your
+architecture, <code class="code">writeFloat()</code> tries to convert it. This is not
+always possible and an <code class="code">Unsupported</code> error is issued if the
+conversion fails and nothing is written to the stream in this case.
+</p>
+</dd>
+<dt id='index-unsigned-long-writeString_0028const-char-_002astr_002c-unsigned-long-amount-_003d-0_0029_003b'><span><code class="code">unsigned long writeString(const char *str, unsigned long amount = 0);</code><a class="copiable-link" href='#index-unsigned-long-writeString_0028const-char-_002astr_002c-unsigned-long-amount-_003d-0_0029_003b'> &para;</a></span></dt>
+<dt id='index-unsigned-long-writeString_0028const-std_003a_003astring-_0026str_0029_003b'><span><code class="code">unsigned long writeString(const std::string &amp;str);</code><a class="copiable-link" href='#index-unsigned-long-writeString_0028const-std_003a_003astring-_0026str_0029_003b'> &para;</a></span></dt>
+<dd><p>Writes a character string to the stream. Both standard C
+<abbr class="acronym">ASCIIZ</abbr> strings and <abbr class="acronym">STL</abbr> <code class="code">string</code> objects are
+supported.
+</p>
+<p>The standard C version takes a pointer <code class="code">str</code> to the
+<abbr class="acronym">ASCIIZ</abbr> string to write as first argument and an optional
+second argument <code class="code">amount</code>, which specifies the number of
+characters to write from that string. If it is omitted, the whole
+string is written to the stream.
+</p>
+<p>For the <code class="code">string</code> object version, the only argument is the
+<code class="code">string</code> object, containing the string to write.
+</p>
+<p>Both methods return the number of characters actually written to the
+stream (which should only differ from the value you wanted to write
+when an error occured).
+</p></dd>
+</dl>
+
+<h4 class="subheading" id="Protected-methods_003a-2">Protected methods:</h4>
+
+<dl class="ftable">
+<dt id='index-virtual-void-putByte_0028Byte_0029'><span><code class="code">virtual void putByte(Byte)</code><a class="copiable-link" href='#index-virtual-void-putByte_0028Byte_0029'> &para;</a></span></dt>
+<dd><p>Abstract virtual method to insert exactly one byte (8 bits) into the
+stream and advance the stream pointer accordingly. The byte to be
+written is passed as the only argument. Implemented by the stream
+layer.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="binstream.html">binstream</a>, Previous: <a href="binistream.html">binistream</a>, Up: <a href="Base-classes.html">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/binstream.html
+++ b/doc/libbinio/1.5/binstream.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>binstream (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="binstream (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="binstream (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Base-classes.html" rel="up" title="Base classes">
+<link href="binostream.html" rel="prev" title="binostream">
+
+
+</head>
+
+<body lang="en">
+<div class="subsection-level-extent" id="binstream">
+<div class="nav-panel">
+<p>
+Previous: <a href="binostream.html" accesskey="p" rel="prev">binostream</a>, Up: <a href="Base-classes.html" accesskey="u" rel="up">Base classes</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h4 class="subsection" id="binstream-1">3.3.4 binstream</h4>
+<a class="index-entry-id" id="index-binstream"></a>
+
+<p><code class="code">binstream</code> provides a both input and output supporting binary
+stream. It inherits the interface from both <code class="code">binistream</code> and
+<code class="code">binostream</code> and defines no additional methods. Refer to the
+documentation of these two classes for more information instead.
+</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/index.html
+++ b/doc/libbinio/1.5/index.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>Top (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="Top (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="Top (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="#Top" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Introduction.html" rel="next" title="Introduction">
+<style type="text/css">
+<!--
+ul.toc-numbered-mark {list-style: none}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+
+
+
+
+
+<div class="top-level-extent" id="Top">
+<div class="nav-panel">
+<p>
+Next: <a href="Introduction.html" accesskey="n" rel="next">Introduction</a> &nbsp; [<a href="#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h1 class="top" id="Binary-I_002fO-stream-class-library">Binary I/O stream class library</h1>
+
+<p>This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+</p>
+<p>Copyright &copy; 2002 - 2005, 2008 Simon Peter
+</p>
+<blockquote class="quotation">
+<p>Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being &ldquo;A GNU Manual,&rdquo;
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled &ldquo;GNU Free Documentation License.&rdquo;
+</p>
+<p>(a) The FSF&rsquo;s Back-Cover Text is: &ldquo;You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development.&rdquo;
+</p></blockquote>
+
+
+<div class="element-contents" id="SEC_Contents">
+<h2 class="contents-heading">Table of Contents</h2>
+
+<div class="contents">
+
+<ul class="toc-numbered-mark">
+  <li><a id="toc-Introduction-1" href="Introduction.html">1 Introduction</a>
+  <ul class="toc-numbered-mark">
+    <li><a id="toc-Features-1" href="Features.html">1.1 Features</a></li>
+  </ul></li>
+  <li><a id="toc-Usage-1" href="Usage.html">2 Usage</a>
+  <ul class="toc-numbered-mark">
+    <li><a id="toc-Basics-1" href="Basics.html">2.1 Basics</a></li>
+    <li><a id="toc-Files-1" href="Files.html">2.2 Files</a></li>
+    <li><a id="toc-Reading-and-Writing-1" href="Reading-and-Writing.html">2.3 Reading and Writing</a></li>
+    <li><a id="toc-Peeking-1" href="Peeking.html">2.4 Peeking</a></li>
+    <li><a id="toc-Seeking-1" href="Seeking.html">2.5 Seeking</a></li>
+    <li><a id="toc-Alien-architectures-1" href="Alien-architectures.html">2.6 Alien architectures</a></li>
+    <li><a id="toc-Wrapping-around-iostream-1" href="Wrapping-around-iostream.html">2.7 Wrapping around iostream</a></li>
+    <li><a id="toc-Errors-1" href="Errors.html">2.8 Errors</a></li>
+    <li><a id="toc-Creating-architecture_002dindependent-file-formats-1" href="Creating-architecture_002dindependent-file-formats.html">2.9 Creating architecture-independent file formats</a></li>
+    <li><a id="toc-Examples-1" href="Examples.html">2.10 Examples</a></li>
+  </ul></li>
+  <li><a id="toc-Reference-1" href="Reference.html">3 Reference</a>
+  <ul class="toc-numbered-mark">
+    <li><a id="toc-Concepts-1" href="Concepts.html">3.1 Concepts</a></li>
+    <li><a id="toc-Configuration-1" href="Configuration.html">3.2 Configuration</a></li>
+    <li><a id="toc-Base-classes-1" href="Base-classes.html">3.3 Base classes</a>
+    <ul class="toc-numbered-mark">
+      <li><a id="toc-binio-1" href="binio.html">3.3.1 binio</a></li>
+      <li><a id="toc-binistream-1" href="binistream.html">3.3.2 binistream</a></li>
+      <li><a id="toc-binostream-1" href="binostream.html">3.3.3 binostream</a></li>
+      <li><a id="toc-binstream-1" href="binstream.html">3.3.4 binstream</a></li>
+    </ul></li>
+    <li><a id="toc-File-streams-1" href="File-streams.html">3.4 File streams</a>
+    <ul class="toc-numbered-mark">
+      <li><a id="toc-binfbase-1" href="binfbase.html">3.4.1 binfbase</a></li>
+      <li><a id="toc-File-stream-classes-1" href="File-stream-classes.html">3.4.2 File stream classes</a></li>
+    </ul></li>
+    <li><a id="toc-String-streams-1" href="String-streams.html">3.5 String streams</a></li>
+    <li><a id="toc-iostream-wrappers-1" href="iostream-wrappers.html">3.6 iostream wrappers</a></li>
+  </ul></li>
+  <li><a id="toc-FAQ-1" href="FAQ.html">Appendix A FAQ</a></li>
+  <li><a id="toc-Copying-This-Manual-1" href="Copying-This-Manual.html">Appendix B Copying This Manual</a>
+  <ul class="toc-numbered-mark">
+    <li><a id="toc-GNU-Free-Documentation-License-1" href="GNU-Free-Documentation-License.html">B.1 GNU Free Documentation License</a>
+    <ul class="toc-numbered-mark">
+      <li><a id="toc-ADDENDUM_003a-How-to-use-this-License-for-your-documents" href="GNU-Free-Documentation-License.html#ADDENDUM_003a-How-to-use-this-License-for-your-documents">B.1.1 ADDENDUM: How to use this License for your documents</a></li>
+    </ul></li>
+  </ul></li>
+  <li><a id="toc-Concept-Index-1" href="Concept-Index.html" rel="index">Concept Index</a></li>
+  <li><a id="toc-Class-Index-1" href="Class-Index.html" rel="index">Class Index</a></li>
+  <li><a id="toc-Method-Index-1" href="Method-Index.html" rel="index">Method Index</a></li>
+  <li><a id="toc-Type_002c-Variable-and-Macro-Index" href="Type-Variable-and-Macro-Index.html" rel="index">Type, Variable and Macro Index</a></li>
+</ul>
+</div>
+</div>
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Next: <a href="Introduction.html" accesskey="n" rel="next">Introduction</a> &nbsp; [<a href="#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/doc/libbinio/1.5/iostream-wrappers.html
+++ b/doc/libbinio/1.5/iostream-wrappers.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<!-- Created by GNU Texinfo 7.0.3, https://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<!-- This manual documents the binary I/O stream class library, version
+1.5. It was last updated on 26 February 2023.
+
+Copyright © 2002 - 2005, 2008 Simon Peter
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.1 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover texts being "A GNU Manual,"
+and with the Back-Cover Texts as in (a) below.  A copy of the license is
+included in the section entitled "GNU Free Documentation License."
+
+(a) The FSF's Back-Cover Text is: "You have freedom to copy and modify
+this GNU Manual, like GNU software.  Copies published by the Free
+Software Foundation raise funds for GNU development." -->
+<title>iostream wrappers (Binary I/O stream class library 1.5)</title>
+
+<meta name="description" content="iostream wrappers (Binary I/O stream class library 1.5)">
+<meta name="keywords" content="iostream wrappers (Binary I/O stream class library 1.5)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="makeinfo">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+
+<link href="index.html" rel="start" title="Top">
+<link href="Concept-Index.html" rel="index" title="Concept Index">
+<link href="index.html#SEC_Contents" rel="contents" title="Table of Contents">
+<link href="Reference.html" rel="up" title="Reference">
+<link href="String-streams.html" rel="prev" title="String streams">
+<style type="text/css">
+<!--
+a.copiable-link {visibility: hidden; text-decoration: none; line-height: 0em}
+span:hover a.copiable-link {visibility: visible}
+-->
+</style>
+
+
+</head>
+
+<body lang="en">
+<div class="section-level-extent" id="iostream-wrappers">
+<div class="nav-panel">
+<p>
+Previous: <a href="String-streams.html" accesskey="p" rel="prev">String streams</a>, Up: <a href="Reference.html" accesskey="u" rel="up">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<h3 class="section" id="iostream-wrappers-1">3.6 iostream wrappers</h3>
+<a class="index-entry-id" id="index-iostream-wrappers-1"></a>
+<a class="index-entry-id" id="index-biniwstream"></a>
+<a class="index-entry-id" id="index-binowstream"></a>
+<a class="index-entry-id" id="index-binwstream"></a>
+
+<p>The iostream wrapper classes provide a way to <em class="dfn">wrap</em> around an
+already existing stream of the standard or traditional C++ iostream
+library, thus providing binary access to such a stream. The wrapper
+classes consist of <code class="code">biniwstream</code>, <code class="code">binowstream</code> and
+<code class="code">binwstream</code>.
+</p>
+<p>The iostream wrapper classes do not provide any extra methods by
+themselves. They just inherit the interface of the general binary
+stream classes. Look there for reference. <code class="code">biniwstream</code> inherits
+from <code class="code">binistream</code>, <code class="code">binowstream</code> inherits from
+<code class="code">binostream</code> and <code class="code">binwstream</code> inherits from both of them.
+</p>
+<p>Remember to <em class="emph">always</em> open the iostream stream with the
+<code class="code">ios::bin</code> flag set, before you wrap it with a binary stream, or
+else you will get strange errors on some operating systems.
+</p>
+<p>All other flags you set on the iostream stream will also indirectly
+affect the wrapped binary stream, so be careful.
+</p>
+<h4 class="subheading" id="Header-file_003a-binwrap_002eh">Header file: <samp class="file">binwrap.h</samp></h4>
+
+<h4 class="subheading" id="Public-methods_003a-6">Public methods:</h4>
+
+<dl class="ftable">
+<dt id='index-biniwstream_0028istream-_002aistr_0029'><span><code class="code">biniwstream(istream *istr)</code><a class="copiable-link" href='#index-biniwstream_0028istream-_002aistr_0029'> &para;</a></span></dt>
+<dt id='index-binowstream_0028ostream-_002aostr_0029'><span><code class="code">binowstream(ostream *ostr)</code><a class="copiable-link" href='#index-binowstream_0028ostream-_002aostr_0029'> &para;</a></span></dt>
+<dt id='index-binwstream_0028iostream-_002astr_0029'><span><code class="code">binwstream(iostream *str)</code><a class="copiable-link" href='#index-binwstream_0028iostream-_002astr_0029'> &para;</a></span></dt>
+<dd><p>The constructor. <code class="code">istr</code>, <code class="code">ostr</code> and <code class="code">str</code> are pointers
+to an appropriate, already existing and open stream from the iostream
+library.
+</p>
+</dd>
+<dt id='index-_007ebiniwstream_0028_0029'><span><code class="code">~biniwstream()</code><a class="copiable-link" href='#index-_007ebiniwstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinowstream_0028_0029'><span><code class="code">~binowstream()</code><a class="copiable-link" href='#index-_007ebinowstream_0028_0029'> &para;</a></span></dt>
+<dt id='index-_007ebinwstream_0028_0029'><span><code class="code">~binwstream()</code><a class="copiable-link" href='#index-_007ebinwstream_0028_0029'> &para;</a></span></dt>
+<dd><p>The destructor.
+</p>
+</dd>
+<dt id='index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029-1'><span><code class="code">virtual void seek(long pos, Offset offs = Set)</code><a class="copiable-link" href='#index-virtual-void-seek_0028long-pos_002c-Offset-offs-_003d-Set_0029-1'> &para;</a></span></dt>
+<dt id='index-virtual-long-pos_0028_0029-2'><span><code class="code">virtual long pos()</code><a class="copiable-link" href='#index-virtual-long-pos_0028_0029-2'> &para;</a></span></dt>
+<dd><p>Implementation of the abstract virtual methods, inherited from
+<code class="code">binio</code>. Refer to the reference of that class for more
+information.
+</p></dd>
+</dl>
+
+</div>
+<hr>
+<div class="nav-panel">
+<p>
+Previous: <a href="String-streams.html">String streams</a>, Up: <a href="Reference.html">Reference</a> &nbsp; [<a href="index.html#SEC_Contents" title="Table of contents" rel="contents">Contents</a>][<a href="Concept-Index.html" title="Index" rel="index">Index</a>]</p>
+</div>
+
+
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
 
     <h1>Documentation</h1>
 
+    <p>Click <a href="doc/libbinio/1.5/index.html">here</a> to view
+    the documentation for version 1.5 online (multipage HTML).</p>
+
     <p>Click <a href="doc/libbinio/1.4/index.html">here</a> to view
     the documentation for version 1.4 online (multipage HTML).</p>
 


### PR DESCRIPTION
Created documentation by doing `make html` in the doc directory, while libbinio 1.5 was checked out, and bringing the resulting files here. Also manually edited index.html

Fixes #10