### PR TITLE
When compiling with mingw, LD needs parameter "-no-undefined" to create shared library (DLL)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ lib_LTLIBRARIES = libbinio.la
 libbinio_la_SOURCES = binio.cpp binfile.cpp binwrap.cpp binstr.cpp
 
 libbinio_la_LDFLAGS = -version-info 1:0:0
+libbinio_la_LDFLAGS += -no-undefined # mingw requires this when making shared DLL files
 
 pkginclude_HEADERS = binio.h binfile.h binwrap.h binstr.h
 


### PR DESCRIPTION
See https://github.com/adplug/adplug/issues/205